### PR TITLE
refactor: C++ code structure improvements for RoutingEval/common

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+BasedOnStyle: Google
+IndentWidth: 4
+AccessModifierOffset: -4
+ColumnLimit: 120
+BreakBeforeBraces: Attach
+DerivePointerAlignment: false
+PointerAlignment: Left
+SortIncludes: true
+IncludeBlocks: Regroup
+SpaceBeforeParens: ControlStatements
+AllowShortFunctionsOnASingleLine: None
+ReflowComments: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       - name: Build routing simulator
         run: make -C RoutingEval/common
 
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
+
+      - name: Check C++ formatting
+        run: |
+          find RoutingEval/common -name '*.cpp' -o -name '*.h' \
+            | grep -v nlohmann \
+            | xargs clang-format --dry-run --Werror
+
       - name: Verify binary exists
         run: test -f RoutingEval/build/RunSimulator
 

--- a/RoutingEval/common/HBSNeuronMapper.cpp
+++ b/RoutingEval/common/HBSNeuronMapper.cpp
@@ -10,16 +10,19 @@
 ************************************************************************************/
 
 #include "HBSNeuronMapper.h"
-#include <iostream>
+
 #include <algorithm>
-#include <random>
 #include <fstream>
+#include <iostream>
 #include <queue>
+#include <random>
 #include <unordered_set>
 
 using json = nlohmann::json;
 
-void HBSNeuronMapper::logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out, std::string prefix = "", bool isLeft = true, int max_leaf_id = -1) {
+void HBSNeuronMapper::logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree,
+                                           std::ostream& out, std::string prefix = "", bool isLeft = true,
+                                           int max_leaf_id = -1) {
     out << prefix;
     out << (isLeft ? "├── " : "└── ");
 
@@ -41,7 +44,8 @@ void HBSNeuronMapper::logCoreTreeRecursive(int node, const std::unordered_map<in
     }
 }
 
-HBSNeuronMapper::HBSNeuronMapper(int total_neurons, int neurons_per_core, const std::vector<std::vector<int>>& conn_matrix)
+HBSNeuronMapper::HBSNeuronMapper(int total_neurons, int neurons_per_core,
+                                 const std::vector<std::vector<int>>& conn_matrix)
     : num_neurons(total_neurons), neurons_per_core(neurons_per_core), connectivity_matrix(conn_matrix) {
     core_count = (num_neurons + neurons_per_core - 1) / neurons_per_core;
     mapNeurons();
@@ -86,12 +90,8 @@ void HBSNeuronMapper::mapNeurons() {
 }
 
 // Helper to build non-binary HBS tree: leaf switches with 4 cores, others binary.
-void HBSNeuronMapper::buildHBSTree(
-    int core_count,
-    std::unordered_map<int, std::vector<int>>& core_tree,
-    std::unordered_map<int, int>& core_parent,
-    int& root_id
-) {
+void HBSNeuronMapper::buildHBSTree(int core_count, std::unordered_map<int, std::vector<int>>& core_tree,
+                                   std::unordered_map<int, int>& core_parent, int& root_id) {
     // Bottom-up: group cores into groups of 4 for leaf-level switches.
     std::vector<int> leaf_cores(core_count);
     std::iota(leaf_cores.begin(), leaf_cores.end(), 0);
@@ -143,7 +143,7 @@ int HBSNeuronMapper::getCoreForNeuron(int neuron_id) const {
     if (it != neuron_to_core.end()) {
         return it->second;
     }
-    return -1; // invalid neuron id
+    return -1;  // invalid neuron id
 }
 
 const std::unordered_map<int, int>& HBSNeuronMapper::getNeuronToCoreMap() const {
@@ -163,7 +163,8 @@ const std::unordered_map<int, int>& HBSNeuronMapper::getCoreParent() const {
 }
 
 // Recursively serialize the core tree as a nested JSON structure
-void HBSNeuronMapper::serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree, json& j) const {
+void HBSNeuronMapper::serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree,
+                                        json& j) const {
     j["core"] = node;
     if (core_tree.find(node) != core_tree.end()) {
         j["children"] = json::array();

--- a/RoutingEval/common/HBSNeuronMapper.h
+++ b/RoutingEval/common/HBSNeuronMapper.h
@@ -14,16 +14,16 @@
 #ifndef HBS_NEURON_MAPPER_H
 #define HBS_NEURON_MAPPER_H
 
-#include <unordered_map>
-#include <vector>
-#include <utility>
+#include <fstream>
 #include <random>
 #include <stdexcept>
-#include <fstream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "nlohmann/json.hpp"  // If you're using JSON (https://github.com/nlohmann/json)
 
 using json = nlohmann::json;
-
 
 class HBSNeuronMapper {
 private:
@@ -32,17 +32,18 @@ private:
     int core_count;
     int root_id;
     std::unordered_map<int, int> neuron_to_core;
-    std::unordered_map<int, std::pair<int, int>> core_children; // left and right child for each core
-    std::unordered_map<int, int> core_parent; // parent for each core
+    std::unordered_map<int, std::pair<int, int>> core_children;  // left and right child for each core
+    std::unordered_map<int, int> core_parent;                    // parent for each core
     std::unordered_map<int, std::vector<int>> core_tree;
-    const std::vector<std::vector<int>>& connectivity_matrix; 
+    const std::vector<std::vector<int>>& connectivity_matrix;
 
     void buildBinaryTree();
 
 public:
     HBSNeuronMapper(int total_neurons, int neurons_per_core, const std::vector<std::vector<int>>& conn_matrix);
     void mapNeurons();
-    void buildHBSTree(int core_count, std::unordered_map<int, std::vector<int>>& core_tree, std::unordered_map<int, int>& core_parent, int& root_id);
+    void buildHBSTree(int core_count, std::unordered_map<int, std::vector<int>>& core_tree,
+                      std::unordered_map<int, int>& core_parent, int& root_id);
     int getCoreForNeuron(int neuron_id) const;
     const std::unordered_map<int, int>& getNeuronToCoreMap() const;
     const std::unordered_map<int, std::vector<int>>& getCoreTree() const;
@@ -50,11 +51,13 @@ public:
     int getParentCore(int core_id) const;
     int getTotalCores() const;
     void exportCoreTreeToJson(const std::string& filename) const;
-    void exportCoreNeuronMapToJson(const std::string& filename) const; 
+    void exportCoreNeuronMapToJson(const std::string& filename) const;
     int getRootId() const;
-    void logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out, std::string prefix, bool isLeft, int max_leaf_id);
+    void logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out,
+                              std::string prefix, bool isLeft, int max_leaf_id);
     void serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree, json& j) const;
-    ~HBSNeuronMapper(){}
+    ~HBSNeuronMapper() {
+    }
 };
 
-#endif // HBS_NEURON_MAPPER_H
+#endif  // HBS_NEURON_MAPPER_H

--- a/RoutingEval/common/HBSNeuronMapper.h
+++ b/RoutingEval/common/HBSNeuronMapper.h
@@ -2,10 +2,10 @@
 //#
 //#   File Name: HBSNeuronMapper.h
 //#   Author:  Ayush Patra
-//#   Description: Maps neurons to cores based on the HBS (Hierarchical Broadcast
-//#                Scheme) routing strategy. Loads an existing neuron-to-core mapping
-//#                and builds a non-binary HBS tree (4-wide leaf switches, binary
-//#                upper levels) for simulating multicast routing.
+//#   Description: Maps neurons to cores based on the HBS (Hierarchical Bit String)
+//#                routing strategy. Loads an existing neuron-to-core mapping and
+//#                builds a non-binary HBS tree (4-wide leaf switches, binary upper
+//#                levels) for simulating multicast routing.
 //#   Version History:
 //#       - 2025-08-06: Initial version
 //#

--- a/RoutingEval/common/HBSNeuronMapper.h
+++ b/RoutingEval/common/HBSNeuronMapper.h
@@ -1,13 +1,13 @@
 //####################################################################################
 //#
-//#   File Name: NeuronMapper.h
+//#   File Name: HBSNeuronMapper.h
 //#   Author:  Ayush Patra
-//#   Description: Maps neurons to cores based on the Neurogrid routing strategy.
-//#                Randomly assigns neurons to cores. Models core-to-core connectivity 
-//#                using a binary tree for simulating multicast routing.
-//#   Version History:        
-//#       - 2025-07-26: Initial version
-//#       - 2025-07-26: Updated to binary tree topology for cores
+//#   Description: Maps neurons to cores based on the HBS (Hierarchical Broadcast
+//#                Scheme) routing strategy. Loads an existing neuron-to-core mapping
+//#                and builds a non-binary HBS tree (4-wide leaf switches, binary
+//#                upper levels) for simulating multicast routing.
+//#   Version History:
+//#       - 2025-08-06: Initial version
 //#
 //####################################################################################
 

--- a/RoutingEval/common/HBSRoutingSimulator.cpp
+++ b/RoutingEval/common/HBSRoutingSimulator.cpp
@@ -12,14 +12,15 @@
 ####################################################################################*/
 
 #include "HBSRoutingSimulator.h"
-#include <queue>
-#include <stack>
-#include <iostream>
+
 #include <cassert>
+#include <iostream>
+#include <queue>
 #include <sstream>
+#include <stack>
 // For JSON output
-#include <nlohmann/json.hpp>
 #include <fstream>
+#include <nlohmann/json.hpp>
 
 static constexpr int MAX_GROUP_SIZE = 4;
 
@@ -32,8 +33,7 @@ bool isSwitch(int nodeId, const unordered_map<int, vector<int>>& coreTree) {
 }
 
 // Assumption: cores exist only at leaves; internal nodes are switches.
-vector<int> collectLeafCores(int node,
-                             const unordered_map<int, vector<int>>& coreTree) {
+vector<int> collectLeafCores(int node, const unordered_map<int, vector<int>>& coreTree) {
     vector<int> leaves;
     if (!isSwitch(node, coreTree)) {
         leaves.push_back(node);
@@ -51,8 +51,10 @@ vector<int> collectLeafCores(int node,
             leaves.push_back(cur);
         } else {
             for (int child : it->second) {
-                if (isSwitch(child, coreTree)) q.push(child);
-                else leaves.push_back(child);
+                if (isSwitch(child, coreTree))
+                    q.push(child);
+                else
+                    leaves.push_back(child);
             }
         }
     }
@@ -60,9 +62,7 @@ vector<int> collectLeafCores(int node,
 }
 
 // Helper: find the index of `child` under parent switch `parent` (0..k-1).
-int childIndexUnder(int parent,
-                    int child,
-                    const unordered_map<int, vector<int>>& coreTree) {
+int childIndexUnder(int parent, int child, const unordered_map<int, vector<int>>& coreTree) {
     auto it = coreTree.find(parent);
     if (it == coreTree.end()) return -1;
     const auto& children = it->second;
@@ -74,30 +74,27 @@ int childIndexUnder(int parent,
 
 // Helper: render a 4-bit mask string for child indices 0..3 (bit0 is child index 0, leftmost)
 static std::string maskToBits(const std::unordered_set<int>& indices) {
-    std::string bits = "0000"; // [0][1][2][3], leftmost is child index 0
+    std::string bits = "0000";  // [0][1][2][3], leftmost is child index 0
     for (int i = 0; i < MAX_GROUP_SIZE; ++i) {
         if (indices.count(i)) bits[i] = '1';
     }
-    return bits; // e.g., "0111" means children {0,1,2}
+    return bits;  // e.g., "0111" means children {0,1,2}
 }
 
+}  // anonymous namespace
 
-} // anonymous namespace
-
-HBSRoutingSimulator::HBSRoutingSimulator(
-    const vector<vector<int>>& connectivityMatrix,
-    const unordered_map<int, int>& neuronToCoreMap,
-    const unordered_map<int, vector<int>>& coreTree,
-    const unordered_map<int, int>& coreParent,
-    Utils routingUtils, 
-    string reportDir)
+HBSRoutingSimulator::HBSRoutingSimulator(const vector<vector<int>>& connectivityMatrix,
+                                         const unordered_map<int, int>& neuronToCoreMap,
+                                         const unordered_map<int, vector<int>>& coreTree,
+                                         const unordered_map<int, int>& coreParent, Utils routingUtils,
+                                         string reportDir)
     : routingUtils(routingUtils),
-      weightThreshold(1.0f), // default; adjust if your Utils exposes a threshold getter
+      weightThreshold(1.0f),  // default; adjust if your Utils exposes a threshold getter
       connectivityMatrix(connectivityMatrix),
       neuronToCoreMap(neuronToCoreMap),
       coreTree(coreTree),
-      coreParent(coreParent), reportDir(reportDir) {
-
+      coreParent(coreParent),
+      reportDir(reportDir) {
     // If Utils exposes a threshold, pick it up (comment out if Utils has no such API)
     // weightThreshold = routingUtils.getWeightThreshold();
 
@@ -105,7 +102,7 @@ HBSRoutingSimulator::HBSRoutingSimulator(
     for (int srcNeuron = 0; srcNeuron < (int)connectivityMatrix.size(); ++srcNeuron) {
         const auto& row = connectivityMatrix[srcNeuron];
         auto n2cIt = neuronToCoreMap.find(srcNeuron);
-        if (n2cIt == neuronToCoreMap.end()) continue; // unmapped neuron
+        if (n2cIt == neuronToCoreMap.end()) continue;  // unmapped neuron
 
         unordered_set<int> tgtCores;
         for (int dstNeuron = 0; dstNeuron < (int)row.size(); ++dstNeuron) {
@@ -139,7 +136,7 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
     const unordered_set<int>& targetCores = itTargets->second;
 
     // Reconstruct target neurons (dst) and their cores for detailed logging
-    std::vector<std::pair<int,int>> targetNeuronCoreList; // (dstNeuron, coreId)
+    std::vector<std::pair<int, int>> targetNeuronCoreList;  // (dstNeuron, coreId)
     const auto& row = connectivityMatrix[sourceNeuron];
     for (int dstNeuron = 0; dstNeuron < (int)row.size(); ++dstNeuron) {
         if (row[dstNeuron] >= weightThreshold) {
@@ -157,7 +154,8 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
     }
 
     // Source core
-    int sourceCore = -1; {
+    int sourceCore = -1;
+    {
         auto itSrc = neuronToCoreMap.find(sourceNeuron);
         if (itSrc != neuronToCoreMap.end()) sourceCore = itSrc->second;
     }
@@ -165,25 +163,33 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
     // --- Summary header logs ---
     routingUtils.logToFile("--- Routing Summary for Neuron " + std::to_string(sourceNeuron) + " ---");
     routingUtils.logToFile("Number of target cores: " + std::to_string(coreToDstNeurons.size()));
-    routingUtils.logToFile("Source neuron " + std::to_string(sourceNeuron) + " belongs to core " + std::to_string(sourceCore));
-    routingUtils.logToFile("For source neuron " + std::to_string(sourceNeuron) + " at core " + std::to_string(sourceCore) + " targets are: ");
+    routingUtils.logToFile("Source neuron " + std::to_string(sourceNeuron) + " belongs to core " +
+                           std::to_string(sourceCore));
+    routingUtils.logToFile("For source neuron " + std::to_string(sourceNeuron) + " at core " +
+                           std::to_string(sourceCore) + " targets are: ");
 
     // Per-core target lists
-    for (auto &kvp : coreToDstNeurons) {
+    for (auto& kvp : coreToDstNeurons) {
         int tCore = kvp.first;
-        auto &dsts = kvp.second;
-        std::ostringstream oss1; oss1 << "Core: " << tCore;
+        auto& dsts = kvp.second;
+        std::ostringstream oss1;
+        oss1 << "Core: " << tCore;
         routingUtils.logToFile(oss1.str());
-        std::ostringstream oss2; oss2 << " Neurons: ";
-        for (size_t i = 0; i < dsts.size(); ++i) { oss2 << dsts[i] << ", "; }
+        std::ostringstream oss2;
+        oss2 << " Neurons: ";
+        for (size_t i = 0; i < dsts.size(); ++i) {
+            oss2 << dsts[i] << ", ";
+        }
         routingUtils.logToFile(oss2.str());
-        routingUtils.logToFile("Target core " + std::to_string(tCore) + " has " + std::to_string(dsts.size()) + " target neurons.");
+        routingUtils.logToFile("Target core " + std::to_string(tCore) + " has " + std::to_string(dsts.size()) +
+                               " target neurons.");
     }
 
     routingUtils.logToFile("Using all actual target cores based on connectivity.");
 
     if (targetNeuronCoreList.empty()) {
-        routingUtils.logToFile("No target cores for source neuron " + std::to_string(sourceNeuron) + ". Skipping routing.");
+        routingUtils.logToFile("No target cores for source neuron " + std::to_string(sourceNeuron) +
+                               ". Skipping routing.");
         return;
     }
 
@@ -197,7 +203,11 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
             oss << targetNeuronCoreList[i].first << "->" << targetNeuronCoreList[i].second;
         }
         oss << "\n[HBS] Unique target cores: ";
-        size_t i = 0; for (int c : targetCores) { if (i++) oss << ", "; oss << c; }
+        size_t i = 0;
+        for (int c : targetCores) {
+            if (i++) oss << ", ";
+            oss << c;
+        }
         routingUtils.logToFile(oss.str());
     }
 
@@ -211,12 +221,13 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
     for (int coreId : targetCores) {
         // Do not send a message to the source's own core, but still log it.
         if (coreId == sourceCore) {
-            routingUtils.logToFile("[HBS] Target core equals source core (" + std::to_string(coreId) + ") — will not send, only logging.");
-            continue; // skip enqueueing this core into parent routing
+            routingUtils.logToFile("[HBS] Target core equals source core (" + std::to_string(coreId) +
+                                   ") — will not send, only logging.");
+            continue;  // skip enqueueing this core into parent routing
         }
         auto pIt = coreParent.find(coreId);
-        if (pIt == coreParent.end()) continue; // orphan core? ignore
-        int parent = pIt->second; // parent switch of the core
+        if (pIt == coreParent.end()) continue;  // orphan core? ignore
+        int parent = pIt->second;               // parent switch of the core
         parentSwitches.insert(parent);
 
         int idx = childIndexUnder(parent, coreId, coreTree);
@@ -226,13 +237,17 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
             // the parent's children and checking descendant relation.
             auto itChildren = coreTree.find(parent);
             if (itChildren == coreTree.end()) {
-                routingUtils.logToFile("[HBS] Warning: parent switch " + std::to_string(parent) + " not found in coreTree. Skipping core " + std::to_string(coreId));
-                continue; // skip this target core; malformed tree
+                routingUtils.logToFile("[HBS] Warning: parent switch " + std::to_string(parent) +
+                                       " not found in coreTree. Skipping core " + std::to_string(coreId));
+                continue;  // skip this target core; malformed tree
             }
             const auto& children = itChildren->second;
             for (int ci = 0; ci < (int)children.size(); ++ci) {
                 int child = children[ci];
-                if (isDescendant(child, coreId)) { idx = ci; break; }
+                if (isDescendant(child, coreId)) {
+                    idx = ci;
+                    break;
+                }
             }
         }
         if (idx < 0) {
@@ -243,11 +258,11 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
     }
 
     // Compute the *global OR* of child indices across all participating parents.
-    std::unordered_map<int, std::unordered_set<int>> localMasks; // parent -> set of child indices with targets
-    unordered_set<int> globalMaskIndices; // e.g., {0,1,2}
+    std::unordered_map<int, std::unordered_set<int>> localMasks;  // parent -> set of child indices with targets
+    unordered_set<int> globalMaskIndices;                         // e.g., {0,1,2}
     for (int parent : parentSwitches) {
         auto it = coreTree.find(parent);
-        if (it == coreTree.end()) continue; // defensive
+        if (it == coreTree.end()) continue;  // defensive
         const auto& children = it->second;
         std::unordered_set<int> localMask;
         for (int ci = 0; ci < (int)children.size() && ci < MAX_GROUP_SIZE; ++ci) {
@@ -266,10 +281,17 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
         for (int parent : parentSwitches) {
             const auto& lm = localMasks[parent];
             oss << "  parent " << parent << ": " << maskToBits(lm) << "  (indices:";
-            int cnt = 0; for (int idx : lm) { oss << (cnt++?",":" ") << idx; } oss << ")\n";
+            int cnt = 0;
+            for (int idx : lm) {
+                oss << (cnt++ ? "," : " ") << idx;
+            }
+            oss << ")\n";
         }
         oss << "Global OR mask: " << maskToBits(globalMaskIndices) << "  (indices:";
-        int cnt = 0; for (int idx : globalMaskIndices) { oss << (cnt++?",":" ") << idx; }
+        int cnt = 0;
+        for (int idx : globalMaskIndices) {
+            oss << (cnt++ ? "," : " ") << idx;
+        }
         oss << ")";
         routingUtils.logToFile(oss.str());
     }
@@ -285,11 +307,11 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
 
     for (int parent : parentSwitches) {
         auto it = coreTree.find(parent);
-        if (it == coreTree.end()) continue; // not a switch? skip
+        if (it == coreTree.end()) continue;  // not a switch? skip
         const auto& children = it->second;
 
         for (int ci : globalMaskIndices) {
-            if (ci < 0 || ci >= (int)children.size() || ci >= MAX_GROUP_SIZE) continue; // enforce 4-wide leaf groups
+            if (ci < 0 || ci >= (int)children.size() || ci >= MAX_GROUP_SIZE) continue;  // enforce 4-wide leaf groups
             int childNode = children[ci];
 
             // Leaf cores under this child subtree
@@ -310,7 +332,8 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
                     oss << "Core-level waste: under parent " << parent << ", child-index " << ci << ": ";
                     int printed = 0;
                     auto ptIt2 = parentToChildIdxTargets[parent].find(ci);
-                    const std::unordered_set<int>* tgtSetPtr = (ptIt2 != parentToChildIdxTargets[parent].end()) ? &ptIt2->second : nullptr;
+                    const std::unordered_set<int>* tgtSetPtr =
+                        (ptIt2 != parentToChildIdxTargets[parent].end()) ? &ptIt2->second : nullptr;
                     for (int c : leaves) {
                         if (!tgtSetPtr || tgtSetPtr->find(c) == tgtSetPtr->end()) {
                             if (printed++) oss << ", ";
@@ -324,11 +347,11 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
                 if (targetCountUnderChild == 0) {
                     // All leaves are waste
                     for (int c : leaves) {
-                        wastedMessages[c] += 1; // one extra illegal delivery
+                        wastedMessages[c] += 1;  // one extra illegal delivery
                     }
                 } else {
                     // Mark only non-target leaves as waste
-                    const auto& tgtSet = ptIt->second; // set of target cores under this child
+                    const auto& tgtSet = ptIt->second;  // set of target cores under this child
                     for (int c : leaves) {
                         if (tgtSet.find(c) == tgtSet.end()) {
                             wastedMessages[c] += 1;
@@ -348,7 +371,7 @@ void HBSRoutingSimulator::traverseTree(int coreId, unordered_set<int>& visitedCo
     if (visitedCores.count(coreId)) return;
     visitedCores.insert(coreId);
     auto it = coreTree.find(coreId);
-    if (it == coreTree.end()) return; // leaf core
+    if (it == coreTree.end()) return;  // leaf core
     for (int child : it->second) traverseTree(child, visitedCores);
 }
 
@@ -379,15 +402,13 @@ void HBSRoutingSimulator::reportWasteStatistics() {
 
     nlohmann::json neuronWasteJson = nlohmann::json::object();
     for (const auto& kv : wastePerNeuron) {
-        if (kv.second > 0)
-            neuronWasteJson[std::to_string(kv.first)] = kv.second;
+        if (kv.second > 0) neuronWasteJson[std::to_string(kv.first)] = kv.second;
     }
     j["per_neuron_waste"] = neuronWasteJson;
 
     nlohmann::json coreWasteJson = nlohmann::json::object();
     for (const auto& kv : wastedMessages) {
-        if (kv.second > 0)
-            coreWasteJson[std::to_string(kv.first)] = kv.second;
+        if (kv.second > 0) coreWasteJson[std::to_string(kv.first)] = kv.second;
     }
     j["per_core_waste"] = coreWasteJson;
 
@@ -426,7 +447,7 @@ int HBSRoutingSimulator::findLCA(int sourceCore, int targetCore) {
         if (it == coreParent.end()) break;
         cur = it->second;
     }
-    return sourceCore; // fallback
+    return sourceCore;  // fallback
 }
 
 bool HBSRoutingSimulator::isDescendant(int current, int target) {
@@ -438,7 +459,7 @@ bool HBSRoutingSimulator::isDescendant(int current, int target) {
         q.pop();
         if (u == target) return true;
         auto it = coreTree.find(u);
-        if (it == coreTree.end()) continue; // leaf
+        if (it == coreTree.end()) continue;  // leaf
         for (int v : it->second) q.push(v);
     }
     return false;
@@ -447,7 +468,7 @@ bool HBSRoutingSimulator::isDescendant(int current, int target) {
 vector<int> HBSRoutingSimulator::shortestPath(int startCore, int endCore) {
     // Build path via parents; no heavy use in current model, provided for debugging
     // Compute ancestors of start
-    unordered_map<int, int> parentMap = coreParent; // copy for local access
+    unordered_map<int, int> parentMap = coreParent;  // copy for local access
 
     unordered_set<int> anc;
     int cur = startCore;
@@ -463,7 +484,10 @@ vector<int> HBSRoutingSimulator::shortestPath(int startCore, int endCore) {
     int lca = endCore;
     while (true) {
         tail.push_back(cur);
-        if (anc.count(cur)) { lca = cur; break; }
+        if (anc.count(cur)) {
+            lca = cur;
+            break;
+        }
         auto it = parentMap.find(cur);
         if (it == parentMap.end()) break;
         cur = it->second;

--- a/RoutingEval/common/HBSRoutingSimulator.cpp
+++ b/RoutingEval/common/HBSRoutingSimulator.cpp
@@ -2,9 +2,9 @@
 #
 #   File Name: HBSRoutingSimulator.cpp
 #   Author:  Ayush Patra
-#   Description: Simulates Neurogrid-style routing from one neuron to another using
-#                a binary tree of switches with 4 cores in the leaves. Computes and 
-#                logs routing waste based on deviation from expected connectivity 
+#   Description: Simulates HBS (Hierarchical Bit String) routing from one neuron to
+#                another using a tree of switches with 4-wide leaf groups. Computes
+#                and logs routing waste based on deviation from expected connectivity
 #                (connectivity matrix).
 #   Version History:
 #       - 2025-08-06: Initial version
@@ -14,13 +14,12 @@
 #include "HBSRoutingSimulator.h"
 
 #include <cassert>
+#include <fstream>
 #include <iostream>
+#include <nlohmann/json.hpp>
 #include <queue>
 #include <sstream>
 #include <stack>
-// For JSON output
-#include <fstream>
-#include <nlohmann/json.hpp>
 
 static constexpr int MAX_GROUP_SIZE = 4;
 
@@ -136,7 +135,51 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
     const unordered_set<int>& targetCores = itTargets->second;
 
     // Reconstruct target neurons (dst) and their cores for detailed logging
-    std::vector<std::pair<int, int>> targetNeuronCoreList;  // (dstNeuron, coreId)
+    auto targetNeuronCoreList = buildTargetNeuronCoreList(sourceNeuron);
+
+    // Build core -> list of target neurons for pretty logging
+    std::unordered_map<int, std::vector<int>> coreToDstNeurons;
+    for (const auto& pr : targetNeuronCoreList) coreToDstNeurons[pr.second].push_back(pr.first);
+
+    // Source core
+    int sourceCore = -1;
+    auto itSrc = neuronToCoreMap.find(sourceNeuron);
+    if (itSrc != neuronToCoreMap.end()) sourceCore = itSrc->second;
+
+    // --- Summary header logs ---
+    logRoutingSummary(sourceNeuron, sourceCore, coreToDstNeurons, targetNeuronCoreList, targetCores);
+
+    if (targetNeuronCoreList.empty()) {
+        routingUtils.logToFile("No target cores for source neuron " + std::to_string(sourceNeuron) +
+                               ". Skipping routing.");
+        return;
+    }
+
+    // Group targets by their *immediate parent switch* and by child-index under that switch.
+    // parentSwitch -> childIndex -> set<coreId>
+    unordered_map<int, unordered_map<int, unordered_set<int>>> parentToChildIdxTargets;
+    unordered_set<int> parentSwitches;
+    buildParentSwitchMap(targetCores, sourceCore, parentToChildIdxTargets, parentSwitches);
+
+    // Compute the *global OR* of child indices across all participating parents.
+    std::unordered_map<int, std::unordered_set<int>> localMasks;
+    unordered_set<int> globalMaskIndices;
+    computeGlobalMask(parentSwitches, parentToChildIdxTargets, localMasks, globalMaskIndices);
+
+    // Route-like hints (no LCA used here, but list explicit target cores)
+    for (const auto& kvp : coreToDstNeurons)
+        routingUtils.logToFile(std::string("Target core: ") + std::to_string(kvp.first));
+
+    // Now, each parent switch broadcasts to every child index in `globalMaskIndices`.
+    // Waste = (#leaf cores under that child) - (#targets under that child at this parent).
+    computeWastePerParent(sourceNeuron, parentSwitches, globalMaskIndices, parentToChildIdxTargets);
+
+    routingUtils.logToFile("Total core-level routing waste: " + std::to_string(wastePerNeuron[sourceNeuron]));
+    routingUtils.logToFile("Finished simulation for source neuron " + std::to_string(sourceNeuron));
+}
+
+std::vector<std::pair<int, int>> HBSRoutingSimulator::buildTargetNeuronCoreList(int sourceNeuron) const {
+    std::vector<std::pair<int, int>> targetNeuronCoreList;
     const auto& row = connectivityMatrix[sourceNeuron];
     for (int dstNeuron = 0; dstNeuron < (int)row.size(); ++dstNeuron) {
         if (row[dstNeuron] >= weightThreshold) {
@@ -146,21 +189,13 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
             }
         }
     }
+    return targetNeuronCoreList;
+}
 
-    // Build core -> list of target neurons for pretty logging
-    std::unordered_map<int, std::vector<int>> coreToDstNeurons;
-    for (const auto& pr : targetNeuronCoreList) {
-        coreToDstNeurons[pr.second].push_back(pr.first);
-    }
-
-    // Source core
-    int sourceCore = -1;
-    {
-        auto itSrc = neuronToCoreMap.find(sourceNeuron);
-        if (itSrc != neuronToCoreMap.end()) sourceCore = itSrc->second;
-    }
-
-    // --- Summary header logs ---
+void HBSRoutingSimulator::logRoutingSummary(int sourceNeuron, int sourceCore,
+                                            const std::unordered_map<int, std::vector<int>>& coreToDstNeurons,
+                                            const std::vector<std::pair<int, int>>& targetNeuronCoreList,
+                                            const std::unordered_set<int>& targetCores) {
     routingUtils.logToFile("--- Routing Summary for Neuron " + std::to_string(sourceNeuron) + " ---");
     routingUtils.logToFile("Number of target cores: " + std::to_string(coreToDstNeurons.size()));
     routingUtils.logToFile("Source neuron " + std::to_string(sourceNeuron) + " belongs to core " +
@@ -169,17 +204,15 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
                            std::to_string(sourceCore) + " targets are: ");
 
     // Per-core target lists
-    for (auto& kvp : coreToDstNeurons) {
+    for (const auto& kvp : coreToDstNeurons) {
         int tCore = kvp.first;
-        auto& dsts = kvp.second;
+        const auto& dsts = kvp.second;
         std::ostringstream oss1;
         oss1 << "Core: " << tCore;
         routingUtils.logToFile(oss1.str());
         std::ostringstream oss2;
         oss2 << " Neurons: ";
-        for (size_t i = 0; i < dsts.size(); ++i) {
-            oss2 << dsts[i] << ", ";
-        }
+        for (size_t i = 0; i < dsts.size(); ++i) oss2 << dsts[i] << ", ";
         routingUtils.logToFile(oss2.str());
         routingUtils.logToFile("Target core " + std::to_string(tCore) + " has " + std::to_string(dsts.size()) +
                                " target neurons.");
@@ -187,37 +220,27 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
 
     routingUtils.logToFile("Using all actual target cores based on connectivity.");
 
-    if (targetNeuronCoreList.empty()) {
-        routingUtils.logToFile("No target cores for source neuron " + std::to_string(sourceNeuron) +
-                               ". Skipping routing.");
-        return;
-    }
-
     // Log: source neuron, list of target neurons and their cores, and the set of target cores
-    {
-        std::ostringstream oss;
-        oss << "[HBS] Source neuron: " << sourceNeuron << "\n";
-        oss << "[HBS] Target neurons (dst -> core): ";
-        for (size_t i = 0; i < targetNeuronCoreList.size(); ++i) {
-            if (i) oss << ", ";
-            oss << targetNeuronCoreList[i].first << "->" << targetNeuronCoreList[i].second;
-        }
-        oss << "\n[HBS] Unique target cores: ";
-        size_t i = 0;
-        for (int c : targetCores) {
-            if (i++) oss << ", ";
-            oss << c;
-        }
-        routingUtils.logToFile(oss.str());
+    std::ostringstream oss;
+    oss << "[HBS] Source neuron: " << sourceNeuron << "\n";
+    oss << "[HBS] Target neurons (dst -> core): ";
+    for (size_t i = 0; i < targetNeuronCoreList.size(); ++i) {
+        if (i) oss << ", ";
+        oss << targetNeuronCoreList[i].first << "->" << targetNeuronCoreList[i].second;
     }
+    oss << "\n[HBS] Unique target cores: ";
+    size_t i = 0;
+    for (int c : targetCores) {
+        if (i++) oss << ", ";
+        oss << c;
+    }
+    routingUtils.logToFile(oss.str());
+}
 
-    // Group targets by their *immediate parent switch* and by child-index under that switch.
-    // parentSwitch -> childIndex -> set<coreId>
-    unordered_map<int, unordered_map<int, unordered_set<int>>> parentToChildIdxTargets;
-
-    // Also collect the set of parent switches that will receive a packet.
-    unordered_set<int> parentSwitches;
-
+void HBSRoutingSimulator::buildParentSwitchMap(
+    const std::unordered_set<int>& targetCores, int sourceCore,
+    std::unordered_map<int, std::unordered_map<int, std::unordered_set<int>>>& parentToChildIdxTargets,
+    std::unordered_set<int>& parentSwitches) {
     for (int coreId : targetCores) {
         // Do not send a message to the source's own core, but still log it.
         if (coreId == sourceCore) {
@@ -256,53 +279,51 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
         }
         parentToChildIdxTargets[parent][idx].insert(coreId);
     }
+}
 
+void HBSRoutingSimulator::computeGlobalMask(
+    const std::unordered_set<int>& parentSwitches,
+    const std::unordered_map<int, std::unordered_map<int, std::unordered_set<int>>>& parentToChildIdxTargets,
+    std::unordered_map<int, std::unordered_set<int>>& localMasks, std::unordered_set<int>& globalMaskIndices) {
     // Compute the *global OR* of child indices across all participating parents.
-    std::unordered_map<int, std::unordered_set<int>> localMasks;  // parent -> set of child indices with targets
-    unordered_set<int> globalMaskIndices;                         // e.g., {0,1,2}
     for (int parent : parentSwitches) {
         auto it = coreTree.find(parent);
         if (it == coreTree.end()) continue;  // defensive
         const auto& children = it->second;
         std::unordered_set<int> localMask;
+        auto parentIt = parentToChildIdxTargets.find(parent);
         for (int ci = 0; ci < (int)children.size() && ci < MAX_GROUP_SIZE; ++ci) {
-            auto ptIt = parentToChildIdxTargets[parent].find(ci);
-            if (ptIt != parentToChildIdxTargets[parent].end() && !ptIt->second.empty()) {
-                localMask.insert(ci);
-                globalMaskIndices.insert(ci);
+            if (parentIt != parentToChildIdxTargets.end()) {
+                auto ptIt = parentIt->second.find(ci);
+                if (ptIt != parentIt->second.end() && !ptIt->second.empty()) {
+                    localMask.insert(ci);
+                    globalMaskIndices.insert(ci);
+                }
             }
         }
         localMasks[parent] = localMask;
     }
 
-    {
-        std::ostringstream oss;
-        oss << "Per-parent masks (bits [0..3], left=child0):\n";
-        for (int parent : parentSwitches) {
-            const auto& lm = localMasks[parent];
-            oss << "  parent " << parent << ": " << maskToBits(lm) << "  (indices:";
-            int cnt = 0;
-            for (int idx : lm) {
-                oss << (cnt++ ? "," : " ") << idx;
-            }
-            oss << ")\n";
-        }
-        oss << "Global OR mask: " << maskToBits(globalMaskIndices) << "  (indices:";
+    // Log per-parent masks and the global OR mask
+    std::ostringstream oss;
+    oss << "Per-parent masks (bits [0..3], left=child0):\n";
+    for (int parent : parentSwitches) {
+        const auto& lm = localMasks[parent];
+        oss << "  parent " << parent << ": " << maskToBits(lm) << "  (indices:";
         int cnt = 0;
-        for (int idx : globalMaskIndices) {
-            oss << (cnt++ ? "," : " ") << idx;
-        }
-        oss << ")";
-        routingUtils.logToFile(oss.str());
+        for (int idx : lm) oss << (cnt++ ? "," : " ") << idx;
+        oss << ")\n";
     }
+    oss << "Global OR mask: " << maskToBits(globalMaskIndices) << "  (indices:";
+    int cnt = 0;
+    for (int idx : globalMaskIndices) oss << (cnt++ ? "," : " ") << idx;
+    oss << ")";
+    routingUtils.logToFile(oss.str());
+}
 
-    // Route-like hints (no LCA used here, but list explicit target cores)
-    for (const auto& kvp : coreToDstNeurons) {
-        routingUtils.logToFile(std::string("Target core: ") + std::to_string(kvp.first));
-    }
-
-    // Now, each parent switch broadcasts to every child index in `globalMaskIndices`.
-    // For each selected child index at a given parent, waste = (#leaf cores under that child) - (#targets under that child at this parent).
+void HBSRoutingSimulator::computeWastePerParent(
+    int sourceNeuron, const std::unordered_set<int>& parentSwitches, const std::unordered_set<int>& globalMaskIndices,
+    const std::unordered_map<int, std::unordered_map<int, std::unordered_set<int>>>& parentToChildIdxTargets) {
     int& srcWaste = wastePerNeuron[sourceNeuron];
 
     for (int parent : parentSwitches) {
@@ -320,50 +341,50 @@ void HBSRoutingSimulator::simulateNeuronToNeuron(int sourceNeuron) {
 
             // Number of *actual* target cores under this child for *this parent*
             int targetCountUnderChild = 0;
-            auto ptIt = parentToChildIdxTargets[parent].find(ci);
-            if (ptIt != parentToChildIdxTargets[parent].end()) {
-                targetCountUnderChild = (int)ptIt->second.size();
+            auto parentIt = parentToChildIdxTargets.find(parent);
+            if (parentIt != parentToChildIdxTargets.end()) {
+                auto ptIt = parentIt->second.find(ci);
+                if (ptIt != parentIt->second.end()) targetCountUnderChild = (int)ptIt->second.size();
             }
 
             int wasteHere = leafCount - targetCountUnderChild;
             if (wasteHere > 0) {
-                {
-                    std::ostringstream oss;
-                    oss << "Core-level waste: under parent " << parent << ", child-index " << ci << ": ";
-                    int printed = 0;
-                    auto ptIt2 = parentToChildIdxTargets[parent].find(ci);
-                    const std::unordered_set<int>* tgtSetPtr =
-                        (ptIt2 != parentToChildIdxTargets[parent].end()) ? &ptIt2->second : nullptr;
-                    for (int c : leaves) {
-                        if (!tgtSetPtr || tgtSetPtr->find(c) == tgtSetPtr->end()) {
-                            if (printed++) oss << ", ";
-                            oss << "core " << c << " was not a target";
-                        }
-                    }
-                    routingUtils.logToFile(oss.str());
+                std::ostringstream oss;
+                oss << "Core-level waste: under parent " << parent << ", child-index " << ci << ": ";
+                int printed = 0;
+                const std::unordered_set<int>* tgtSetPtr = nullptr;
+                if (parentIt != parentToChildIdxTargets.end()) {
+                    auto ptIt2 = parentIt->second.find(ci);
+                    if (ptIt2 != parentIt->second.end()) tgtSetPtr = &ptIt2->second;
                 }
+                for (int c : leaves) {
+                    if (!tgtSetPtr || tgtSetPtr->find(c) == tgtSetPtr->end()) {
+                        if (printed++) oss << ", ";
+                        oss << "core " << c << " was not a target";
+                    }
+                }
+                routingUtils.logToFile(oss.str());
                 srcWaste += wasteHere;
+
                 // Attribute waste to the receiving non-target leaf cores
                 if (targetCountUnderChild == 0) {
                     // All leaves are waste
-                    for (int c : leaves) {
-                        wastedMessages[c] += 1;  // one extra illegal delivery
-                    }
+                    for (int c : leaves) wastedMessages[c] += 1;  // one extra illegal delivery
                 } else {
                     // Mark only non-target leaves as waste
-                    const auto& tgtSet = ptIt->second;  // set of target cores under this child
-                    for (int c : leaves) {
-                        if (tgtSet.find(c) == tgtSet.end()) {
-                            wastedMessages[c] += 1;
+                    if (parentIt != parentToChildIdxTargets.end()) {
+                        auto ptIt3 = parentIt->second.find(ci);
+                        if (ptIt3 != parentIt->second.end()) {
+                            const auto& tgtSet = ptIt3->second;  // set of target cores under this child
+                            for (int c : leaves) {
+                                if (tgtSet.find(c) == tgtSet.end()) wastedMessages[c] += 1;
+                            }
                         }
                     }
                 }
             }
         }
     }
-
-    routingUtils.logToFile("Total core-level routing waste: " + std::to_string(wastePerNeuron[sourceNeuron]));
-    routingUtils.logToFile("Finished simulation for source neuron " + std::to_string(sourceNeuron));
 }
 
 void HBSRoutingSimulator::traverseTree(int coreId, unordered_set<int>& visitedCores) {

--- a/RoutingEval/common/HBSRoutingSimulator.h
+++ b/RoutingEval/common/HBSRoutingSimulator.h
@@ -42,21 +42,21 @@ private:
     //void routeMessage(int srcCore, int tgtCore, std::unordered_set<int>& visitedCores);
 
 public:
-        HBSRoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
-                         const std::unordered_map<int, int>& neuronToCoreMap,
-                         const std::unordered_map<int, std::vector<int>>& coreTree,
-                         const std::unordered_map<int, int>& coreParent,
+    HBSRoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
+                        const std::unordered_map<int, int>& neuronToCoreMap,
+                        const std::unordered_map<int, std::vector<int>>& coreTree,
+                        const std::unordered_map<int, int>& coreParent,
                         Utils routingUtils,
                         string reportDir);
-    
-        void simulate();
-        void reportWasteStatistics();
-        long long getTotalWaste() const;
-        std::unordered_map<int, int> getWastedMessagesPerCore() const;
-        int findLCA(int sourceCore, int targetCore);
-        bool isDescendant(int current, int target);
-        std::vector<int> shortestPath(int startCore, int endCore);
-        ~HBSRoutingSimulator(){}
+
+    void simulate();
+    void reportWasteStatistics();
+    long long getTotalWaste() const;
+    std::unordered_map<int, int> getWastedMessagesPerCore() const;
+    int findLCA(int sourceCore, int targetCore);
+    bool isDescendant(int current, int target);
+    std::vector<int> shortestPath(int startCore, int endCore);
+    ~HBSRoutingSimulator(){}
 };
 
 #endif // HBS_ROUTING_SIMULATOR_H

--- a/RoutingEval/common/HBSRoutingSimulator.h
+++ b/RoutingEval/common/HBSRoutingSimulator.h
@@ -14,11 +14,12 @@
 #ifndef HBS_ROUTING_SIMULATOR_H
 #define HBS_ROUTING_SIMULATOR_H
 
-#include <vector>
+#include <algorithm>
+#include <map>
 #include <unordered_map>
 #include <unordered_set>
-#include <map>
-#include <algorithm>
+#include <vector>
+
 #include "Utils.h"
 
 class HBSRoutingSimulator {
@@ -31,12 +32,12 @@ private:
     const std::unordered_map<int, std::vector<int>>& coreTree;
     const std::unordered_map<int, int>& coreParent;
     string reportDir;
-    
+
     std::unordered_map<int, std::unordered_set<int>> actualTargetsPerNeuron;
     std::unordered_map<int, std::unordered_set<int>> visitedNeuronsPerNeuron;
     std::map<int, int> wastePerNeuron;
     std::unordered_map<int, int> wastedMessages;
-    
+
     void traverseTree(int coreId, std::unordered_set<int>& visitedCores);
     void simulateNeuronToNeuron(int sourceNeuron);
     //void routeMessage(int srcCore, int tgtCore, std::unordered_set<int>& visitedCores);
@@ -45,9 +46,7 @@ public:
     HBSRoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
                         const std::unordered_map<int, int>& neuronToCoreMap,
                         const std::unordered_map<int, std::vector<int>>& coreTree,
-                        const std::unordered_map<int, int>& coreParent,
-                        Utils routingUtils,
-                        string reportDir);
+                        const std::unordered_map<int, int>& coreParent, Utils routingUtils, string reportDir);
 
     void simulate();
     void reportWasteStatistics();
@@ -56,7 +55,8 @@ public:
     int findLCA(int sourceCore, int targetCore);
     bool isDescendant(int current, int target);
     std::vector<int> shortestPath(int startCore, int endCore);
-    ~HBSRoutingSimulator(){}
+    ~HBSRoutingSimulator() {
+    }
 };
 
-#endif // HBS_ROUTING_SIMULATOR_H
+#endif  // HBS_ROUTING_SIMULATOR_H

--- a/RoutingEval/common/HBSRoutingSimulator.h
+++ b/RoutingEval/common/HBSRoutingSimulator.h
@@ -40,7 +40,29 @@ private:
 
     void traverseTree(int coreId, std::unordered_set<int>& visitedCores);
     void simulateNeuronToNeuron(int sourceNeuron);
-    //void routeMessage(int srcCore, int tgtCore, std::unordered_set<int>& visitedCores);
+
+    // Helper: reconstruct (dstNeuron, coreId) pairs from the connectivity row
+    std::vector<std::pair<int, int>> buildTargetNeuronCoreList(int sourceNeuron) const;
+    // Helper: log the routing summary header and per-core target lists
+    void logRoutingSummary(int sourceNeuron, int sourceCore,
+                           const std::unordered_map<int, std::vector<int>>& coreToDstNeurons,
+                           const std::vector<std::pair<int, int>>& targetNeuronCoreList,
+                           const std::unordered_set<int>& targetCores);
+    // Helper: group each target core by its parent switch and child index
+    void buildParentSwitchMap(
+        const std::unordered_set<int>& targetCores, int sourceCore,
+        std::unordered_map<int, std::unordered_map<int, std::unordered_set<int>>>& parentToChildIdxTargets,
+        std::unordered_set<int>& parentSwitches);
+    // Helper: compute global OR mask of child indices across all parent switches, and log it
+    void computeGlobalMask(
+        const std::unordered_set<int>& parentSwitches,
+        const std::unordered_map<int, std::unordered_map<int, std::unordered_set<int>>>& parentToChildIdxTargets,
+        std::unordered_map<int, std::unordered_set<int>>& localMasks, std::unordered_set<int>& globalMaskIndices);
+    // Helper: compute and accumulate waste for each parent under the global mask
+    void computeWastePerParent(
+        int sourceNeuron, const std::unordered_set<int>& parentSwitches,
+        const std::unordered_set<int>& globalMaskIndices,
+        const std::unordered_map<int, std::unordered_map<int, std::unordered_set<int>>>& parentToChildIdxTargets);
 
 public:
     HBSRoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,

--- a/RoutingEval/common/HBSRoutingSimulator.h
+++ b/RoutingEval/common/HBSRoutingSimulator.h
@@ -2,9 +2,9 @@
 #
 #   File Name: HBSRoutingSimulator.h
 #   Author:  Ayush Patra
-#   Description: Simulates Neurogrid-style routing from one neuron to another using
-#                a binary tree of switches with 4 cores in the leaves. Computes and 
-#                logs routing waste based on deviation from expected connectivity 
+#   Description: Simulates HBS (Hierarchical Bit String) routing from one neuron to
+#                another using a tree of switches with 4-wide leaf groups. Computes
+#                and logs routing waste based on deviation from expected connectivity
 #                (connectivity matrix).
 #   Version History:
 #       - 2025-08-06: Initial version

--- a/RoutingEval/common/NeuronMapper.cpp
+++ b/RoutingEval/common/NeuronMapper.cpp
@@ -50,43 +50,47 @@ NeuronMapper::NeuronMapper(int total_neurons, int neurons_per_core, const std::v
 }
 
 void NeuronMapper::assignNeuronsToCores() {
-    std::ifstream infile("../data/neuron_to_core_map.json");
-    if (infile.good()) {
-        json j;
-        infile >> j;
-        infile.close();
-        for (auto& [key, val] : j.items()) {
-            // Skip any non-numeric keys defensively (e.g., comments or extra fields)
-            bool numeric = !key.empty() && std::all_of(key.begin(), key.end(), [](char c) {
-                return c == '-' || std::isdigit(static_cast<unsigned char>(c));
-            });
-            if (!numeric) continue;
-            int core = 0;
-            try {
-                core = std::stoi(key);
-            } catch (...) {
-                continue;
-            }
-            if (!val.is_array()) continue;
-            for (int neuron : val) {
-                neuron_to_core[neuron] = core;
-            }
-        }
-        {
-            std::unordered_set<int> distinct;
-            for (const auto& [_, core] : neuron_to_core) distinct.insert(core);
-            core_count = (int)distinct.size();
-        }
-        // Compare existing mapping's core count with required cores from parameters
-        int required_cores = (num_neurons + neurons_per_core - 1) / neurons_per_core;  // ceil division
-        if (core_count == required_cores) {
-            // Reuse existing mapping as-is
-            return;
-        }
-        // Otherwise, rebuild a fresh neuron_to_core mapping below
-        neuron_to_core.clear();
-    }
+    if (loadExistingMapping()) return;
+    clusterNeuronsBFS();
+    exportCoreNeuronMapToJson("../data/neuron_to_core_map.json");
+}
 
+bool NeuronMapper::loadExistingMapping() {
+    std::ifstream infile("../data/neuron_to_core_map.json");
+    if (!infile.good()) return false;
+
+    json j;
+    infile >> j;
+    infile.close();
+    for (auto& [key, val] : j.items()) {
+        // Skip any non-numeric keys defensively (e.g., comments or extra fields)
+        bool numeric = !key.empty() && std::all_of(key.begin(), key.end(), [](char c) {
+            return c == '-' || std::isdigit(static_cast<unsigned char>(c));
+        });
+        if (!numeric) continue;
+        int core = 0;
+        try {
+            core = std::stoi(key);
+        } catch (...) {
+            continue;
+        }
+        if (!val.is_array()) continue;
+        for (int neuron : val) neuron_to_core[neuron] = core;
+    }
+    {
+        std::unordered_set<int> distinct;
+        for (const auto& [_, core] : neuron_to_core) distinct.insert(core);
+        core_count = (int)distinct.size();
+    }
+    // Compare existing mapping's core count with required cores from parameters
+    int required_cores = (num_neurons + neurons_per_core - 1) / neurons_per_core;  // ceil division
+    if (core_count == required_cores) return true;
+    // Core count mismatch — discard and rebuild
+    neuron_to_core.clear();
+    return false;
+}
+
+void NeuronMapper::clusterNeuronsBFS() {
     int num_cores = (num_neurons + neurons_per_core - 1) / neurons_per_core;  // ceil division
     std::vector<std::vector<int>> clusters(num_cores);
     std::vector<bool> visited(num_neurons, false);
@@ -122,13 +126,9 @@ void NeuronMapper::assignNeuronsToCores() {
     }
 
     for (int c = 0; c < num_cores; ++c) {
-        for (int neuron : clusters[c]) {
-            neuron_to_core[neuron] = c;
-        }
+        for (int neuron : clusters[c]) neuron_to_core[neuron] = c;
     }
-
     core_count = num_cores;
-    exportCoreNeuronMapToJson("../data/neuron_to_core_map.json");
 }
 
 void NeuronMapper::mapNeurons() {
@@ -137,11 +137,28 @@ void NeuronMapper::mapNeurons() {
     core_children.clear();
     core_parent.clear();
 
+    buildBinaryTree();
+    exportCoreTreeToJson("../data/core_tree/core_tree.json");
+
+    int root = -1;
+    for (const auto& [node, parent] : core_parent) {
+        if (parent == -1) {
+            root = node;
+            break;
+        }
+    }
+    std::ofstream logFile("../data/core_tree/core_tree_structure.txt");
+    if (logFile && root != -1) {
+        logFile << "Binary Core Tree Structure:\n";
+        logCoreTreeRecursive(root, core_tree, logFile, "", false, -1);
+        logFile.close();
+    }
+}
+
+void NeuronMapper::buildBinaryTree() {
     int next_id = core_count;
     std::vector<int> current_level;
-    for (int i = 0; i < core_count; ++i) {
-        current_level.push_back(i);
-    }
+    for (int i = 0; i < core_count; ++i) current_level.push_back(i);
 
     while (current_level.size() > 1) {
         std::vector<int> next_level;
@@ -170,23 +187,9 @@ void NeuronMapper::mapNeurons() {
 
     if (!current_level.empty()) {
         int root = current_level[0];
-        if (core_parent.find(root) == core_parent.end()) {
-            core_parent[root] = -1;
-        }
+        if (core_parent.find(root) == core_parent.end()) core_parent[root] = -1;
     }
-
     core_count = next_id;
-
-    exportCoreTreeToJson("../data/core_tree/core_tree.json");
-
-    std::ofstream logFile("../data/core_tree/core_tree_structure.txt");
-    if (logFile) {
-        logFile << "Binary Core Tree Structure:\n";
-        if (!current_level.empty()) {
-            logCoreTreeRecursive(current_level[0], core_tree, logFile, "", false, core_count - (next_id - core_count));
-        }
-        logFile.close();
-    }
 }
 
 int NeuronMapper::getCoreForNeuron(int neuron_id) const {

--- a/RoutingEval/common/NeuronMapper.cpp
+++ b/RoutingEval/common/NeuronMapper.cpp
@@ -10,15 +10,18 @@
 ************************************************************************************/
 
 #include "NeuronMapper.h"
+
 #include <algorithm>
-#include <random>
 #include <fstream>
 #include <queue>
+#include <random>
 #include <unordered_set>
 
 using json = nlohmann::json;
 
-void NeuronMapper::logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out, std::string prefix = "", bool isLeft = true, int max_leaf_id = -1) {
+void NeuronMapper::logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree,
+                                        std::ostream& out, std::string prefix = "", bool isLeft = true,
+                                        int max_leaf_id = -1) {
     out << prefix;
     out << (isLeft ? "├── " : "└── ");
 
@@ -54,10 +57,16 @@ void NeuronMapper::assignNeuronsToCores() {
         infile.close();
         for (auto& [key, val] : j.items()) {
             // Skip any non-numeric keys defensively (e.g., comments or extra fields)
-            bool numeric = !key.empty() && std::all_of(key.begin(), key.end(), [](char c){ return c=='-' || std::isdigit(static_cast<unsigned char>(c)); });
+            bool numeric = !key.empty() && std::all_of(key.begin(), key.end(), [](char c) {
+                return c == '-' || std::isdigit(static_cast<unsigned char>(c));
+            });
             if (!numeric) continue;
             int core = 0;
-            try { core = std::stoi(key); } catch (...) { continue; }
+            try {
+                core = std::stoi(key);
+            } catch (...) {
+                continue;
+            }
             if (!val.is_array()) continue;
             for (int neuron : val) {
                 neuron_to_core[neuron] = core;
@@ -69,7 +78,7 @@ void NeuronMapper::assignNeuronsToCores() {
             core_count = (int)distinct.size();
         }
         // Compare existing mapping's core count with required cores from parameters
-        int required_cores = (num_neurons + neurons_per_core - 1) / neurons_per_core; // ceil division
+        int required_cores = (num_neurons + neurons_per_core - 1) / neurons_per_core;  // ceil division
         if (core_count == required_cores) {
             // Reuse existing mapping as-is
             return;
@@ -78,7 +87,7 @@ void NeuronMapper::assignNeuronsToCores() {
         neuron_to_core.clear();
     }
 
-    int num_cores = (num_neurons + neurons_per_core - 1) / neurons_per_core; // ceil division
+    int num_cores = (num_neurons + neurons_per_core - 1) / neurons_per_core;  // ceil division
     std::vector<std::vector<int>> clusters(num_cores);
     std::vector<bool> visited(num_neurons, false);
     std::vector<int> neuron_ids(num_neurons);
@@ -92,7 +101,8 @@ void NeuronMapper::assignNeuronsToCores() {
         q.push(i);
         visited[i] = true;
         while (!q.empty() && static_cast<int>(clusters[cluster_index].size()) < neurons_per_core) {
-            int n = q.front(); q.pop();
+            int n = q.front();
+            q.pop();
             clusters[cluster_index].push_back(n);
             for (int j = 0; j < num_neurons; ++j) {
                 if (!visited[j] && n != j && connectivity_matrix[n][j] > 0) {
@@ -184,7 +194,7 @@ int NeuronMapper::getCoreForNeuron(int neuron_id) const {
     if (it != neuron_to_core.end()) {
         return it->second;
     }
-    return -1; // invalid neuron id
+    return -1;  // invalid neuron id
 }
 
 const std::unordered_map<int, int>& NeuronMapper::getNeuronToCoreMap() const {
@@ -204,7 +214,8 @@ const std::unordered_map<int, int>& NeuronMapper::getCoreParent() const {
 }
 
 // Recursively serialize the core tree as a nested JSON structure
-void NeuronMapper::serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree, json& j) const {
+void NeuronMapper::serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree,
+                                     json& j) const {
     j["core"] = node;
     if (core_tree.find(node) != core_tree.end()) {
         j["children"] = json::array();

--- a/RoutingEval/common/NeuronMapper.h
+++ b/RoutingEval/common/NeuronMapper.h
@@ -3,9 +3,9 @@
 //#   File Name: NeuronMapper.h
 //#   Author:  Ayush Patra
 //#   Description: Maps neurons to cores based on the Neurogrid routing strategy.
-//#                Randomly assigns neurons to cores. Models core-to-core connectivity 
+//#                Randomly assigns neurons to cores. Models core-to-core connectivity
 //#                using a binary tree for simulating multicast routing.
-//#   Version History:        
+//#   Version History:
 //#       - 2025-07-26: Initial version
 //#       - 2025-07-26: Updated to binary tree topology for cores
 //#
@@ -14,12 +14,13 @@
 #ifndef NEURON_MAPPER_H
 #define NEURON_MAPPER_H
 
-#include <unordered_map>
-#include <vector>
-#include <utility>
+#include <fstream>
 #include <random>
 #include <stdexcept>
-#include <fstream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "nlohmann/json.hpp"  // If you're using JSON (https://github.com/nlohmann/json)
 
 using json = nlohmann::json;
@@ -30,10 +31,10 @@ private:
     int neurons_per_core;
     int core_count;
     std::unordered_map<int, int> neuron_to_core;
-    std::unordered_map<int, std::pair<int, int>> core_children; // left and right child for each core
-    std::unordered_map<int, int> core_parent; // parent for each core
+    std::unordered_map<int, std::pair<int, int>> core_children;  // left and right child for each core
+    std::unordered_map<int, int> core_parent;                    // parent for each core
     std::unordered_map<int, std::vector<int>> core_tree;
-    const std::vector<std::vector<int>>& connectivity_matrix; 
+    const std::vector<std::vector<int>>& connectivity_matrix;
 
     void buildBinaryTree();
 
@@ -48,10 +49,12 @@ public:
     int getParentCore(int core_id) const;
     int getTotalCores() const;
     void exportCoreTreeToJson(const std::string& filename) const;
-    void exportCoreNeuronMapToJson(const std::string& filename) const; 
-    void logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out, std::string prefix, bool isLeft, int max_leaf_id);
+    void exportCoreNeuronMapToJson(const std::string& filename) const;
+    void logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out,
+                              std::string prefix, bool isLeft, int max_leaf_id);
     void serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree, json& j) const;
-    ~NeuronMapper(){}
+    ~NeuronMapper() {
+    }
 };
 
-#endif // NEURON_MAPPER_H
+#endif  // NEURON_MAPPER_H

--- a/RoutingEval/common/NeuronMapper.h
+++ b/RoutingEval/common/NeuronMapper.h
@@ -36,7 +36,17 @@ private:
     std::unordered_map<int, std::vector<int>> core_tree;
     const std::vector<std::vector<int>>& connectivity_matrix;
 
+    // Helper: load existing JSON mapping; returns true if core count matches required
+    bool loadExistingMapping();
+    // Helper: BFS-based clustering of neurons into cores by connectivity
+    void clusterNeuronsBFS();
+    // Helper: build binary tree over leaf cores, populating core_tree and core_parent
     void buildBinaryTree();
+    // Helper: recursively log the core tree structure to an output stream
+    void logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out,
+                              std::string prefix, bool isLeft, int max_leaf_id);
+    // Helper: recursively serialize core tree to a nested JSON object
+    void serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree, json& j) const;
 
 public:
     NeuronMapper(int total_neurons, int neurons_per_core, const std::vector<std::vector<int>>& conn_matrix);
@@ -46,13 +56,9 @@ public:
     const std::unordered_map<int, int>& getNeuronToCoreMap() const;
     const std::unordered_map<int, std::vector<int>>& getCoreTree() const;
     const std::unordered_map<int, int>& getCoreParent() const;
-    int getParentCore(int core_id) const;
     int getTotalCores() const;
     void exportCoreTreeToJson(const std::string& filename) const;
     void exportCoreNeuronMapToJson(const std::string& filename) const;
-    void logCoreTreeRecursive(int node, const std::unordered_map<int, std::vector<int>>& core_tree, std::ostream& out,
-                              std::string prefix, bool isLeft, int max_leaf_id);
-    void serializeCoreTree(int node, const std::unordered_map<int, std::vector<int>>& core_tree, json& j) const;
     ~NeuronMapper() {
     }
 };

--- a/RoutingEval/common/RoutingSimulator.cpp
+++ b/RoutingEval/common/RoutingSimulator.cpp
@@ -20,12 +20,7 @@
 #include <set>
 #include <algorithm>
 #include <fstream>
-// Write JSON summary to file using nlohmann::json
 #include <nlohmann/json.hpp>
-nlohmann::json j;
-
-// Definition for the root core used in LCA checks
-const int rootCore = 30;
 
 RoutingSimulator::RoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
                                    const std::unordered_map<int, int>& neuronToCoreMap,
@@ -45,8 +40,13 @@ RoutingSimulator::RoutingSimulator(const std::vector<std::vector<int>>& connecti
       }
 
 void RoutingSimulator::simulate() {
+    nlohmann::json j;
 
-    //let us first start with checking the mappings.
+    int rootCore = -1;
+    for (const auto& kv : coreParent) {
+        if (kv.second == -1) { rootCore = kv.first; break; }
+    }
+
     wastePerNeuron.clear();
     wastedMessages.clear();
     

--- a/RoutingEval/common/RoutingSimulator.cpp
+++ b/RoutingEval/common/RoutingSimulator.cpp
@@ -7,8 +7,8 @@
  *                based on a static neuron connectivity matrix.
  *   Version History:
  *       - 2025-07-26: Initial version
- *       - 2025-07-27: Added support for neuron and core level waste calculation. 
- *       - 2025-07-31: Added support for checking the route, and storing it. 
+ *       - 2025-07-27: Added support for neuron and core level waste calculation.
+ *       - 2025-07-31: Added support for checking the route, and storing it.
  *
  **********************************************************************************/
 
@@ -38,49 +38,14 @@ RoutingSimulator::RoutingSimulator(const std::vector<std::vector<int>>& connecti
 }
 
 void RoutingSimulator::simulate() {
-    nlohmann::json j;
-
-    int rootCore = -1;
-    for (const auto& kv : coreParent) {
-        if (kv.second == -1) {
-            rootCore = kv.first;
-            break;
-        }
-    }
-
     wastePerNeuron.clear();
     wastedMessages.clear();
 
+    int rootCore = findRootCore();
     int numNeurons = connectivityMatrix.size();
+
     for (int src = 0; src < numNeurons; ++src) {
-        // int src = rand() % numNeurons; // Randomly select a source neuron for debuggin only.
-
-        //Printing all target neurons and the target cores.
-
-        std::map<int, vector<int>> targetCores;
-        for (int i = 0; i < numNeurons; i++) {
-            if (connectivityMatrix[src][i] > weightThreshold && neuronToCoreMap.find(i) != neuronToCoreMap.end()) {
-                int core = neuronToCoreMap.at(i);
-                int sourceCore = neuronToCoreMap.count(src) ? neuronToCoreMap.at(src) : -1;
-                // Skip if target core is the same as source core
-                if (core != sourceCore) {
-                    targetCores[core].push_back(i);
-                }
-            }
-        }
-
-        //For each Neuron, producing a Routing Summary.
-
-        routingUtils.logToFile("--- Routing Summary for Neuron " + std::to_string(src) + " ---");
-        routingUtils.logToFile("Number of target cores: " + to_string(targetCores.size()));
-
-        // In case there are NO target CORES (This neuron did not fire at all during evaluation of 155 time steps)
-        if (targetCores.empty()) {
-            routingUtils.logToFile("No target cores for source neuron " + std::to_string(src) + ". Skipping routing.");
-            continue;
-        }
-
-        //else continue.
+        // int src = rand() % numNeurons; // Randomly select a source neuron for debugging only.
 
         // error scenario where core is not found.
         if (neuronToCoreMap.find(src) == neuronToCoreMap.end()) {
@@ -88,122 +53,163 @@ void RoutingSimulator::simulate() {
             continue;
         }
 
-        //find the source core of the nueorn.
+        // Printing all target neurons and the target cores.
+        auto targetCores = buildTargetCores(src);
 
+        // For each Neuron, producing a Routing Summary.
+        routingUtils.logToFile("--- Routing Summary for Neuron " + std::to_string(src) + " ---");
+        routingUtils.logToFile("Number of target cores: " + std::to_string(targetCores.size()));
+
+        // In case there are NO target CORES (This neuron did not fire at all during evaluation of 155 time steps)
+        if (targetCores.empty()) {
+            routingUtils.logToFile("No target cores for source neuron " + std::to_string(src) + ". Skipping routing.");
+            continue;
+        }
+
+        // Find the source core of the neuron.
         int srcCore = neuronToCoreMap.at(src);
         routingUtils.logToFile("Source neuron " + std::to_string(src) + " belongs to core " + std::to_string(srcCore));
 
-        routingUtils.logToFile("For source neuron " + to_string(src) + " at core " + to_string(srcCore) +
+        // Logging the target neurons.
+        routingUtils.logToFile("For source neuron " + std::to_string(src) + " at core " + std::to_string(srcCore) +
                                " targets are: ");
-
-        //logging the target neurons.
         for (auto& it : targetCores) {
-            string st = "";
-            for (int num : it.second) st += to_string(num) + ", ";
-            routingUtils.logToFile("Core: " + to_string(it.first) + " \n Neurons: " + st);
+            string st;
+            for (int num : it.second) st += std::to_string(num) + ", ";
+            routingUtils.logToFile("Core: " + std::to_string(it.first) + " \n Neurons: " + st);
             routingUtils.logToFile("Target core " + std::to_string(it.first) + " has " +
                                    std::to_string(it.second.size()) + " target neurons.");
         }
 
-        // Build sets for all visited cores and target cores (excluding srcCore)
+        // Build set of actual target cores (excluding srcCore).
+        // Revert to using all actual target cores derived from connectivity matrix.
         std::unordered_set<int> actualTargetCores;
         for (const auto& [tgtCore, neuronList] : targetCores) {
-            if (tgtCore != srcCore) {
-                actualTargetCores.insert(tgtCore);
-            }
+            if (tgtCore != srcCore) actualTargetCores.insert(tgtCore);
         }
-
-        // Revert to using all actual target cores derived from connectivity matrix
         routingUtils.logToFile("Using all actual target cores based on connectivity.");
-        // `actualTargetCores` already populated above and left unchanged
 
         // --- LCA computation logic using findLCA ---
-        int lcaCore;
-        if (!actualTargetCores.empty()) {
-            if (actualTargetCores.size() == 1) {
-                int targetCore = *actualTargetCores.begin();
-                if (targetCore != srcCore)
-                    lcaCore = findLCA(srcCore, targetCore);
-                else
-                    lcaCore = srcCore;
-            } else {
-                auto minmax = std::minmax_element(actualTargetCores.begin(), actualTargetCores.end());
-                lcaCore = findLCA(*minmax.first, *minmax.second);
-            }
-            routingUtils.logToFile("LCA : " + to_string(lcaCore));
-            if (coreParent.find(lcaCore) == coreParent.end() && lcaCore != rootCore) {
-                routingUtils.logToFile("Error: coreParent not found for core " + std::to_string(lcaCore));
-                routingUtils.logToFile("LCA was not correctly reached. Ending path without B.");
-                continue;
-            }
-        } else {
-            routingUtils.logToFile("No valid target cores for LCA computation. Skipping routing.");
-            continue;
-        }
+        int lcaCore = computeLCA(srcCore, actualTargetCores, rootCore);
+        if (lcaCore == -1) continue;
 
-        // Now route once from srcCore to LCA using shortestPath and new routing logic
-        std::vector<int> upPath = shortestPath(srcCore, lcaCore);
-        std::string routingPath = "";
-        std::unordered_set<int> visited;
-
-        int i = 0;
-        while (i < static_cast<int>(upPath.size()) && upPath[i] != rootCore && upPath[i] != lcaCore) {
-            routingPath += "U";
-            visited.insert(upPath[i]);
-            ++i;
-        }
-
-        if (upPath[i] == lcaCore) {
-            routingPath += "B";  // reached LCA directly
-        } else {
-            routingPath += "D";  // start descent to LCA
-            for (++i; i < static_cast<int>(upPath.size()); ++i) {
-                int parent = upPath[i - 1];
-                int child = upPath[i];
-                routingPath += (child < parent ? "L" : "R");
-            }
-            routingPath += "B";  // reached LCA and chose to broadcast
-        }
+        // Now route once from srcCore to LCA using shortestPath and new routing logic.
+        std::string routingPath = traceRoutingPath(srcCore, lcaCore, rootCore);
         routingUtils.logToFile("Route: " + routingPath);
         for (int tgt : actualTargetCores) routingUtils.logToFile(" -> Core " + std::to_string(tgt));
 
-        // --- Compute waste for other subtrees under the LCA, but only count *leaf* descendants (real cores) ---
-        // Identify all leaf descendants of LCA
-        std::unordered_set<int> leafDescendants;
-        std::function<void(int)> collectLeafDescendants = [&](int node) {
-            if (coreTree.find(node) == coreTree.end()) {
-                leafDescendants.insert(node);  // it's a leaf
-                return;
-            }
-            for (int child : coreTree.at(node)) {
-                collectLeafDescendants(child);
-            }
-        };
-        collectLeafDescendants(lcaCore);
-
-        routingUtils.logToFile("Visited real cores (leaf descendants under LCA " + std::to_string(lcaCore) + "):");
-        std::string visitedStr = "";
-        for (int core : leafDescendants) {
-            visitedStr += std::to_string(core) + " ";
-        }
-        routingUtils.logToFile(visitedStr);
-
-        int totalCoreWaste = 0;
-        for (int leaf : leafDescendants) {
-            if (actualTargetCores.find(leaf) == actualTargetCores.end()) {
-                routingUtils.logToFile("Core-level waste: core " + std::to_string(leaf) + " under LCA " +
-                                       std::to_string(lcaCore) + " was not a target.");
-                wastedMessages[leaf]++;
-                totalCoreWaste++;
-            }
-        }
-
-        routingUtils.logToFile("Total core-level routing waste: " + std::to_string(totalCoreWaste));
-        wastePerNeuron[src] = totalCoreWaste;
-
+        // --- Compute waste for other subtrees under the LCA ---
+        int waste = computeWasteUnderLCA(src, lcaCore, actualTargetCores);
+        routingUtils.logToFile("Total core-level routing waste: " + std::to_string(waste));
         routingUtils.logToFile("Finished simulation for source neuron " + std::to_string(src));
     }
 
+    writeReport();
+}
+
+int RoutingSimulator::findRootCore() const {
+    for (const auto& kv : coreParent)
+        if (kv.second == -1) return kv.first;
+    return -1;
+}
+
+std::map<int, std::vector<int>> RoutingSimulator::buildTargetCores(int src) const {
+    std::map<int, std::vector<int>> targetCores;
+    int numNeurons = connectivityMatrix.size();
+    int sourceCore = neuronToCoreMap.count(src) ? neuronToCoreMap.at(src) : -1;
+    for (int i = 0; i < numNeurons; i++) {
+        if (connectivityMatrix[src][i] > weightThreshold && neuronToCoreMap.find(i) != neuronToCoreMap.end()) {
+            int core = neuronToCoreMap.at(i);
+            // Skip if target core is the same as source core
+            if (core != sourceCore) targetCores[core].push_back(i);
+        }
+    }
+    return targetCores;
+}
+
+// Returns -1 if routing should be skipped for this neuron.
+int RoutingSimulator::computeLCA(int srcCore, const std::unordered_set<int>& actualTargetCores, int rootCore) {
+    if (actualTargetCores.empty()) {
+        routingUtils.logToFile("No valid target cores for LCA computation. Skipping routing.");
+        return -1;
+    }
+
+    int lcaCore;
+    if (actualTargetCores.size() == 1) {
+        int targetCore = *actualTargetCores.begin();
+        lcaCore = (targetCore != srcCore) ? findLCA(srcCore, targetCore) : srcCore;
+    } else {
+        auto minmax = std::minmax_element(actualTargetCores.begin(), actualTargetCores.end());
+        lcaCore = findLCA(*minmax.first, *minmax.second);
+    }
+
+    routingUtils.logToFile("LCA : " + std::to_string(lcaCore));
+    if (coreParent.find(lcaCore) == coreParent.end() && lcaCore != rootCore) {
+        routingUtils.logToFile("Error: coreParent not found for core " + std::to_string(lcaCore));
+        routingUtils.logToFile("LCA was not correctly reached. Ending path without B.");
+        return -1;
+    }
+
+    return lcaCore;
+}
+
+std::string RoutingSimulator::traceRoutingPath(int srcCore, int lcaCore, int rootCore) {
+    std::vector<int> upPath = shortestPath(srcCore, lcaCore);
+    std::string routingPath;
+
+    int i = 0;
+    while (i < static_cast<int>(upPath.size()) && upPath[i] != rootCore && upPath[i] != lcaCore) {
+        routingPath += "U";
+        ++i;
+    }
+
+    if (upPath[i] == lcaCore) {
+        routingPath += "B";  // reached LCA directly
+    } else {
+        routingPath += "D";  // start descent to LCA
+        for (++i; i < static_cast<int>(upPath.size()); ++i) {
+            int parent = upPath[i - 1];
+            int child = upPath[i];
+            routingPath += (child < parent ? "L" : "R");
+        }
+        routingPath += "B";  // reached LCA and chose to broadcast
+    }
+
+    return routingPath;
+}
+
+int RoutingSimulator::computeWasteUnderLCA(int src, int lcaCore, const std::unordered_set<int>& actualTargetCores) {
+    // Identify all leaf descendants of LCA — only count *leaf* descendants (real cores, not switches)
+    std::unordered_set<int> leafDescendants;
+    std::function<void(int)> collectLeaves = [&](int node) {
+        if (coreTree.find(node) == coreTree.end()) {
+            leafDescendants.insert(node);  // it's a leaf core
+            return;
+        }
+        for (int child : coreTree.at(node)) collectLeaves(child);
+    };
+    collectLeaves(lcaCore);
+
+    routingUtils.logToFile("Visited real cores (leaf descendants under LCA " + std::to_string(lcaCore) + "):");
+    std::string visitedStr;
+    for (int core : leafDescendants) visitedStr += std::to_string(core) + " ";
+    routingUtils.logToFile(visitedStr);
+
+    int totalCoreWaste = 0;
+    for (int leaf : leafDescendants) {
+        if (actualTargetCores.find(leaf) == actualTargetCores.end()) {
+            routingUtils.logToFile("Core-level waste: core " + std::to_string(leaf) + " under LCA " +
+                                   std::to_string(lcaCore) + " was not a target.");
+            wastedMessages[leaf]++;
+            totalCoreWaste++;
+        }
+    }
+
+    wastePerNeuron[src] = totalCoreWaste;
+    return totalCoreWaste;
+}
+
+void RoutingSimulator::writeReport() {
     // === Final waste summary (core-level only) ===
     long long totalWasteAll = 0;
     for (const auto& kv : wastePerNeuron) totalWasteAll += kv.second;
@@ -212,32 +218,29 @@ void RoutingSimulator::simulate() {
     routingUtils.logToFile("Total illegal deliveries (waste): " + std::to_string(totalWasteAll));
 
     routingUtils.logToFile("Per-neuron waste (non-zero only):");
-    for (const auto& kv : wastePerNeuron) {
+    for (const auto& kv : wastePerNeuron)
         if (kv.second > 0)
             routingUtils.logToFile("  Neuron " + std::to_string(kv.first) + ": " + std::to_string(kv.second));
-    }
 
     routingUtils.logToFile("Per-core waste (non-zero only):");
-    for (const auto& kv : wastedMessages) {
+    for (const auto& kv : wastedMessages)
         if (kv.second > 0)
             routingUtils.logToFile("  Core " + std::to_string(kv.first) + ": " + std::to_string(kv.second));
-    }
+
     routingUtils.logToFile("==================================");
 
+    // Save waste metrics to JSON report file
+    nlohmann::json j;
     j["total_illegal_deliveries"] = totalWasteAll;
     nlohmann::json per_neuron, per_core;
-    for (const auto& kv : wastePerNeuron) {
+    for (const auto& kv : wastePerNeuron)
         if (kv.second > 0) per_neuron[std::to_string(kv.first)] = kv.second;
-    }
-    for (const auto& kv : wastedMessages) {
+    for (const auto& kv : wastedMessages)
         if (kv.second > 0) per_core[std::to_string(kv.first)] = kv.second;
-    }
     j["per_neuron_waste"] = per_neuron;
     j["per_core_waste"] = per_core;
 
-    // Save to JSON file (replace .txt with .json if present)
-    std::string jsonReportPath = reportDir;
-    std::ofstream jout(jsonReportPath);
+    std::ofstream jout(reportDir);
     if (jout.is_open()) {
         jout << j.dump(4) << std::endl;
         jout.close();

--- a/RoutingEval/common/RoutingSimulator.cpp
+++ b/RoutingEval/common/RoutingSimulator.cpp
@@ -13,53 +13,53 @@
  **********************************************************************************/
 
 #include "RoutingSimulator.h"
-#include <iostream>
-#include <queue>
-#include <unordered_set>
-#include <random>
-#include <set>
+
 #include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <nlohmann/json.hpp>
+#include <queue>
+#include <random>
+#include <set>
+#include <unordered_set>
 
 RoutingSimulator::RoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
                                    const std::unordered_map<int, int>& neuronToCoreMap,
                                    const std::unordered_map<int, std::vector<int>>& coreTree,
-                                   const std::unordered_map<int, int>& coreParent,
-                                   Utils routingUtils,
-                                   string reportDir
-                                )
+                                   const std::unordered_map<int, int>& coreParent, Utils routingUtils, string reportDir)
     : connectivityMatrix(connectivityMatrix),
       neuronToCoreMap(neuronToCoreMap),
       coreTree(coreTree),
       coreParent(coreParent),
       routingUtils(routingUtils),
       reportDir(reportDir) {
-        srand(time(0));
-        weightThreshold = 0;
-      }
+    srand(time(0));
+    weightThreshold = 0;
+}
 
 void RoutingSimulator::simulate() {
     nlohmann::json j;
 
     int rootCore = -1;
     for (const auto& kv : coreParent) {
-        if (kv.second == -1) { rootCore = kv.first; break; }
+        if (kv.second == -1) {
+            rootCore = kv.first;
+            break;
+        }
     }
 
     wastePerNeuron.clear();
     wastedMessages.clear();
-    
+
     int numNeurons = connectivityMatrix.size();
     for (int src = 0; src < numNeurons; ++src) {
-    // int src = rand() % numNeurons; // Randomly select a source neuron for debuggin only. 
+        // int src = rand() % numNeurons; // Randomly select a source neuron for debuggin only.
 
-        //Printing all target neurons and the target cores. 
-
+        //Printing all target neurons and the target cores.
 
         std::map<int, vector<int>> targetCores;
-        for(int i = 0; i<numNeurons; i++){
-            if(connectivityMatrix[src][i] > weightThreshold && neuronToCoreMap.find(i) != neuronToCoreMap.end()) {
+        for (int i = 0; i < numNeurons; i++) {
+            if (connectivityMatrix[src][i] > weightThreshold && neuronToCoreMap.find(i) != neuronToCoreMap.end()) {
                 int core = neuronToCoreMap.at(i);
                 int sourceCore = neuronToCoreMap.count(src) ? neuronToCoreMap.at(src) : -1;
                 // Skip if target core is the same as source core
@@ -69,12 +69,10 @@ void RoutingSimulator::simulate() {
             }
         }
 
-
-        //For each Neuron, producing a Routing Summary. 
-
+        //For each Neuron, producing a Routing Summary.
 
         routingUtils.logToFile("--- Routing Summary for Neuron " + std::to_string(src) + " ---");
-        routingUtils.logToFile("Number of target cores: "+to_string(targetCores.size()));
+        routingUtils.logToFile("Number of target cores: " + to_string(targetCores.size()));
 
         // In case there are NO target CORES (This neuron did not fire at all during evaluation of 155 time steps)
         if (targetCores.empty()) {
@@ -82,29 +80,29 @@ void RoutingSimulator::simulate() {
             continue;
         }
 
+        //else continue.
 
-        //else continue. 
-
-        // error scenario where core is not found. 
+        // error scenario where core is not found.
         if (neuronToCoreMap.find(src) == neuronToCoreMap.end()) {
             routingUtils.logToFile("Skipping src neuron " + std::to_string(src) + ": no core mapping.");
             continue;
         }
 
-        //find the source core of the nueorn. 
+        //find the source core of the nueorn.
 
         int srcCore = neuronToCoreMap.at(src);
         routingUtils.logToFile("Source neuron " + std::to_string(src) + " belongs to core " + std::to_string(srcCore));
 
-        routingUtils.logToFile("For source neuron "+to_string(src)+" at core "+to_string(srcCore)+" targets are: ");
+        routingUtils.logToFile("For source neuron " + to_string(src) + " at core " + to_string(srcCore) +
+                               " targets are: ");
 
-        //logging the target neurons. 
-        for(auto& it: targetCores){
+        //logging the target neurons.
+        for (auto& it : targetCores) {
             string st = "";
-            for(int num: it.second)
-                st += to_string(num)+", ";
-            routingUtils.logToFile("Core: "+to_string(it.first)+" \n Neurons: "+st);
-            routingUtils.logToFile("Target core " + std::to_string(it.first) + " has " + std::to_string(it.second.size()) + " target neurons.");
+            for (int num : it.second) st += to_string(num) + ", ";
+            routingUtils.logToFile("Core: " + to_string(it.first) + " \n Neurons: " + st);
+            routingUtils.logToFile("Target core " + std::to_string(it.first) + " has " +
+                                   std::to_string(it.second.size()) + " target neurons.");
         }
 
         // Build sets for all visited cores and target cores (excluding srcCore)
@@ -132,7 +130,7 @@ void RoutingSimulator::simulate() {
                 auto minmax = std::minmax_element(actualTargetCores.begin(), actualTargetCores.end());
                 lcaCore = findLCA(*minmax.first, *minmax.second);
             }
-            routingUtils.logToFile("LCA : "+to_string(lcaCore));
+            routingUtils.logToFile("LCA : " + to_string(lcaCore));
             if (coreParent.find(lcaCore) == coreParent.end() && lcaCore != rootCore) {
                 routingUtils.logToFile("Error: coreParent not found for core " + std::to_string(lcaCore));
                 routingUtils.logToFile("LCA was not correctly reached. Ending path without B.");
@@ -167,8 +165,7 @@ void RoutingSimulator::simulate() {
             routingPath += "B";  // reached LCA and chose to broadcast
         }
         routingUtils.logToFile("Route: " + routingPath);
-        for (int tgt : actualTargetCores)
-            routingUtils.logToFile(" -> Core " + std::to_string(tgt));
+        for (int tgt : actualTargetCores) routingUtils.logToFile(" -> Core " + std::to_string(tgt));
 
         // --- Compute waste for other subtrees under the LCA, but only count *leaf* descendants (real cores) ---
         // Identify all leaf descendants of LCA
@@ -194,7 +191,8 @@ void RoutingSimulator::simulate() {
         int totalCoreWaste = 0;
         for (int leaf : leafDescendants) {
             if (actualTargetCores.find(leaf) == actualTargetCores.end()) {
-                routingUtils.logToFile("Core-level waste: core " + std::to_string(leaf) + " under LCA " + std::to_string(lcaCore) + " was not a target.");
+                routingUtils.logToFile("Core-level waste: core " + std::to_string(leaf) + " under LCA " +
+                                       std::to_string(lcaCore) + " was not a target.");
                 wastedMessages[leaf]++;
                 totalCoreWaste++;
             }
@@ -208,31 +206,31 @@ void RoutingSimulator::simulate() {
 
     // === Final waste summary (core-level only) ===
     long long totalWasteAll = 0;
-    for (const auto &kv : wastePerNeuron) totalWasteAll += kv.second;
+    for (const auto& kv : wastePerNeuron) totalWasteAll += kv.second;
 
     routingUtils.logToFile("\n==== Neurogrid Routing Waste Report ====");
     routingUtils.logToFile("Total illegal deliveries (waste): " + std::to_string(totalWasteAll));
 
     routingUtils.logToFile("Per-neuron waste (non-zero only):");
-    for (const auto &kv : wastePerNeuron) {
-        if (kv.second > 0) routingUtils.logToFile("  Neuron " + std::to_string(kv.first) + ": " + std::to_string(kv.second));
+    for (const auto& kv : wastePerNeuron) {
+        if (kv.second > 0)
+            routingUtils.logToFile("  Neuron " + std::to_string(kv.first) + ": " + std::to_string(kv.second));
     }
 
     routingUtils.logToFile("Per-core waste (non-zero only):");
-    for (const auto &kv : wastedMessages) {
-        if (kv.second > 0) routingUtils.logToFile("  Core " + std::to_string(kv.first) + ": " + std::to_string(kv.second));
+    for (const auto& kv : wastedMessages) {
+        if (kv.second > 0)
+            routingUtils.logToFile("  Core " + std::to_string(kv.first) + ": " + std::to_string(kv.second));
     }
     routingUtils.logToFile("==================================");
 
     j["total_illegal_deliveries"] = totalWasteAll;
     nlohmann::json per_neuron, per_core;
     for (const auto& kv : wastePerNeuron) {
-        if (kv.second > 0)
-            per_neuron[std::to_string(kv.first)] = kv.second;
+        if (kv.second > 0) per_neuron[std::to_string(kv.first)] = kv.second;
     }
     for (const auto& kv : wastedMessages) {
-        if (kv.second > 0)
-            per_core[std::to_string(kv.first)] = kv.second;
+        if (kv.second > 0) per_core[std::to_string(kv.first)] = kv.second;
     }
     j["per_neuron_waste"] = per_neuron;
     j["per_core_waste"] = per_core;

--- a/RoutingEval/common/RoutingSimulator.h
+++ b/RoutingEval/common/RoutingSimulator.h
@@ -39,7 +39,19 @@ private:
 
     void traverseTree(int coreId, std::unordered_set<int>& visitedCores);
     void simulateNeuronToNeuron(int sourceNeuron);
-    //void routeMessage(int srcCore, int tgtCore, std::unordered_set<int>& visitedCores);
+
+    // Helper: finds the root node of the core tree (the one with no parent)
+    int findRootCore() const;
+    // Helper: builds the map of target cores → target neurons for a source neuron
+    std::map<int, std::vector<int>> buildTargetCores(int src) const;
+    // Helper: resolves the LCA across all target cores; returns -1 if routing should be skipped
+    int computeLCA(int srcCore, const std::unordered_set<int>& actualTargetCores, int rootCore);
+    // Helper: traces the U/D/L/R/B routing path from srcCore up to the LCA
+    std::string traceRoutingPath(int srcCore, int lcaCore, int rootCore);
+    // Helper: counts waste as non-target leaf cores under the LCA subtree
+    int computeWasteUnderLCA(int src, int lcaCore, const std::unordered_set<int>& actualTargetCores);
+    // Helper: logs the final waste summary and writes the JSON report to disk
+    void writeReport();
 
 public:
     RoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,

--- a/RoutingEval/common/RoutingSimulator.h
+++ b/RoutingEval/common/RoutingSimulator.h
@@ -13,11 +13,12 @@
 #ifndef ROUTING_SIMULATOR_H
 #define ROUTING_SIMULATOR_H
 
-#include <vector>
+#include <algorithm>
+#include <map>
 #include <unordered_map>
 #include <unordered_set>
-#include <map>
-#include <algorithm>
+#include <vector>
+
 #include "Utils.h"
 
 class RoutingSimulator {
@@ -30,12 +31,12 @@ private:
     Utils routingUtils;
     float weightThreshold;
     string reportDir;
-    
+
     std::unordered_map<int, std::unordered_set<int>> actualTargetsPerNeuron;
     std::unordered_map<int, std::unordered_set<int>> visitedNeuronsPerNeuron;
     std::map<int, int> wastePerNeuron;
     std::unordered_map<int, int> wastedMessages;
-    
+
     void traverseTree(int coreId, std::unordered_set<int>& visitedCores);
     void simulateNeuronToNeuron(int sourceNeuron);
     //void routeMessage(int srcCore, int tgtCore, std::unordered_set<int>& visitedCores);
@@ -44,9 +45,7 @@ public:
     RoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
                      const std::unordered_map<int, int>& neuronToCoreMap,
                      const std::unordered_map<int, std::vector<int>>& coreTree,
-                     const std::unordered_map<int, int>& coreParent,
-                     Utils routingUtils,
-                     string reportDir);
+                     const std::unordered_map<int, int>& coreParent, Utils routingUtils, string reportDir);
 
     void simulate();
     void reportWasteStatistics() const;
@@ -55,7 +54,8 @@ public:
     int findLCA(int sourceCore, int targetCore);
     bool isDescendant(int current, int target);
     std::vector<int> shortestPath(int startCore, int endCore);
-    ~RoutingSimulator(){}
+    ~RoutingSimulator() {
+    }
 };
 
-#endif // ROUTING_SIMULATOR_H
+#endif  // ROUTING_SIMULATOR_H

--- a/RoutingEval/common/RoutingSimulator.h
+++ b/RoutingEval/common/RoutingSimulator.h
@@ -41,21 +41,21 @@ private:
     //void routeMessage(int srcCore, int tgtCore, std::unordered_set<int>& visitedCores);
 
 public:
-        RoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
-                         const std::unordered_map<int, int>& neuronToCoreMap,
-                         const std::unordered_map<int, std::vector<int>>& coreTree,
-                         const std::unordered_map<int, int>& coreParent,
-                        Utils routingUtils,
-                        string reportDir);
-    
-        void simulate();
-        void reportWasteStatistics() const;
-        long long getTotalWaste() const;
-        std::unordered_map<int, int> getWastedMessagesPerCore() const;
-        int findLCA(int sourceCore, int targetCore);
-        bool isDescendant(int current, int target);
-        std::vector<int> shortestPath(int startCore, int endCore);
-        ~RoutingSimulator(){}
+    RoutingSimulator(const std::vector<std::vector<int>>& connectivityMatrix,
+                     const std::unordered_map<int, int>& neuronToCoreMap,
+                     const std::unordered_map<int, std::vector<int>>& coreTree,
+                     const std::unordered_map<int, int>& coreParent,
+                     Utils routingUtils,
+                     string reportDir);
+
+    void simulate();
+    void reportWasteStatistics() const;
+    long long getTotalWaste() const;
+    std::unordered_map<int, int> getWastedMessagesPerCore() const;
+    int findLCA(int sourceCore, int targetCore);
+    bool isDescendant(int current, int target);
+    std::vector<int> shortestPath(int startCore, int endCore);
+    ~RoutingSimulator(){}
 };
 
 #endif // ROUTING_SIMULATOR_H

--- a/RoutingEval/common/SpikeGenerator.cpp
+++ b/RoutingEval/common/SpikeGenerator.cpp
@@ -12,8 +12,8 @@
 *
 ************************************************************************************/
 
-
 #include "SpikeGenerator.h"
+
 #include <unordered_set>
 
 // Constructor

--- a/RoutingEval/common/SpikeGenerator.h
+++ b/RoutingEval/common/SpikeGenerator.h
@@ -2,8 +2,8 @@
  *
  *   File Name: SpikeGenerator.h
  *   Author: Ayush Patra
- *   Description: Utility class to generate spike events for neurons during routing
- *                simulation. Spikes can be generated randomly or read from a file.
+ *   Description: Utility class to manage spike events for neurons during routing
+ *                simulation. Tracks which neurons fired at a given timestep.
  *   Version History:
  *       - 2025-07-26: Initial version
  *
@@ -12,28 +12,20 @@
 #ifndef SPIKE_GENERATOR_H
 #define SPIKE_GENERATOR_H
 
-#include <vector>
-#include <random>
-#include <string>
+#include <unordered_set>
 
 class SpikeGenerator {
 public:
-    // Constructor
-    SpikeGenerator(int num_neurons);
+    SpikeGenerator();
 
-    // Generate random spikes
-    std::vector<int> generateRandomSpikes(float spike_prob);
+    void setSpikingNeurons(const std::unordered_set<int>& spikingNeurons);
+    bool isSpiking(int neuronId) const;
+    const std::unordered_set<int>& getSpikingNeurons() const;
 
-    // Load spike data from a file
-    bool loadSpikesFromFile(const std::string& filepath);
-
-    // Get the list of spiking neurons
-    std::vector<int> getSpikingNeurons() const;
-    ~SpikeGenerator(){}
+    ~SpikeGenerator() {}
 
 private:
-    int num_neurons_;
-    std::vector<int> spikes_; // list of firing neurons
+    std::unordered_set<int> spikingNeurons;
 };
 
 #endif // SPIKE_GENERATOR_H

--- a/RoutingEval/common/SpikeGenerator.h
+++ b/RoutingEval/common/SpikeGenerator.h
@@ -22,10 +22,11 @@ public:
     bool isSpiking(int neuronId) const;
     const std::unordered_set<int>& getSpikingNeurons() const;
 
-    ~SpikeGenerator() {}
+    ~SpikeGenerator() {
+    }
 
 private:
     std::unordered_set<int> spikingNeurons;
 };
 
-#endif // SPIKE_GENERATOR_H
+#endif  // SPIKE_GENERATOR_H

--- a/RoutingEval/common/Utils.cpp
+++ b/RoutingEval/common/Utils.cpp
@@ -11,10 +11,13 @@
 ************************************************************************************/
 
 #include "Utils.h"
-#include <iostream>
-#include <fstream>
-#include <sstream>
+
 #include <sys/stat.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
 #include "nlohmann/json.hpp"
 using json = nlohmann::json;
 
@@ -26,10 +29,10 @@ Utils::Utils() {
     logToFile("Utils initialized, logging started...");
 }
 
-void Utils::setConnectivityMatrix(string matrixFilePath){
+void Utils::setConnectivityMatrix(string matrixFilePath) {
     connectivityMatrixFilePath = matrixFilePath;
     logToFile("NEW SAMPLE DATA LOADED.");
-    try{
+    try {
         connectivityMatrix = loadConnectivityMatrix(connectivityMatrixFilePath);
     } catch (const exception& e) {
         cerr << "Error loading connectivity matrix: " << e.what() << endl;
@@ -37,12 +40,13 @@ void Utils::setConnectivityMatrix(string matrixFilePath){
         return;
     }
     logToFile("Connectivity matrix loaded from: " + connectivityMatrixFilePath);
-    logToFile("Connectivity matrix dimensions: " + to_string(connectivityMatrix.size()) + "x" + to_string(connectivityMatrix[0].size()));
+    logToFile("Connectivity matrix dimensions: " + to_string(connectivityMatrix.size()) + "x" +
+              to_string(connectivityMatrix[0].size()));
 }
 
 void Utils::printConnectivityMatrix() {
     // this will print the matrix for the connectivity matrix
-    // can be used for core neuron mapping as well. 
+    // can be used for core neuron mapping as well.
     logToFile("Connecticity matrix:");
     for (const auto& row : connectivityMatrix) {
         string r = "";
@@ -55,15 +59,15 @@ void Utils::printConnectivityMatrix() {
 
 void Utils::printNeuronMap() {
     // this will print the matrix for the connectivity matrix
-    // can be used for core neuron mapping as well. 
+    // can be used for core neuron mapping as well.
     logToFile("Neuron map:");
-    for(const auto& pair : neuronCoreMap) {
+    for (const auto& pair : neuronCoreMap) {
         logToFile("Neuron " + to_string(pair.first) + " -> Core " + to_string(pair.second));
     }
 }
 
 vector<vector<int>> Utils::loadConnectivityMatrix(const string& filePath) {
-    //connecticity matrix is made from the python script. 
+    //connecticity matrix is made from the python script.
     ifstream file(filePath);
     vector<vector<int>> matrix;
 
@@ -78,7 +82,7 @@ vector<vector<int>> Utils::loadConnectivityMatrix(const string& filePath) {
     for (const auto& row : j) {
         vector<int> binaryRow;
         for (const auto& val : row) {
-            binaryRow.push_back(val>weightThreshold? 1: 0);
+            binaryRow.push_back(val > weightThreshold ? 1 : 0);
         }
         matrix.push_back(binaryRow);
     }
@@ -110,7 +114,7 @@ void Utils::logToFile(const string& message) {
     }
 }
 
-string Utils::createLogFileName(){
+string Utils::createLogFileName() {
     // Ensure the logs directory exists before writing
     mkdir("../logs", 0755);
     time_t now = time(0);

--- a/RoutingEval/common/Utils.cpp
+++ b/RoutingEval/common/Utils.cpp
@@ -21,20 +21,9 @@ using json = nlohmann::json;
 using namespace std;
 
 Utils::Utils() {
-        weightThreshold = 0.0435f;
-        logFileName = createLogFileName();
-        logToFile("Utils initialized, logging started...");
-        // // Load the connectivity matrix from the specified file
-        // try{
-        //     connectivityMatrix = loadConnectivityMatrix(connectivityMatrixFilePath);
-        // } catch (const exception& e) {
-        //     cerr << "Error loading connectivity matrix: " << e.what() << endl;
-        //     logToFile("Error loading connectivity matrix: " + string(e.what()));
-        //     return;
-        // }
-        // logToFile("Connectivity matrix loaded from: " + connectivityMatrixFilePath);
-        // logToFile("Connectivity matrix dimensions: " + to_string(connectivityMatrix.size()) + "x" + to_string(connectivityMatrix[0].size()));
-        //printConnectivityMatrix();
+    weightThreshold = 0.0435f;
+    logFileName = createLogFileName();
+    logToFile("Utils initialized, logging started...");
 }
 
 void Utils::setConnectivityMatrix(string matrixFilePath){

--- a/RoutingEval/common/Utils.h
+++ b/RoutingEval/common/Utils.h
@@ -10,16 +10,15 @@
 #
 ####################################################################################*/
 
-
 #ifndef UTILS_H
 #define UTILS_H
 
-#include <string>
-#include <vector>
-#include <unordered_map>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 using namespace std;
 
@@ -30,28 +29,29 @@ private:
     string connectivityMatrixFilePath;
     vector<vector<int>> connectivityMatrix;
     unordered_map<int, int> neuronCoreMap;
+
 public:
-    Utils(); // updated definition
-	// Prints a matrix to stdout (for debug)
-	void printConnectivityMatrix();
+    Utils();  // updated definition
+    // Prints a matrix to stdout (for debug)
+    void printConnectivityMatrix();
 
     // Prints a matrix to stdout (for debug)
-	void printNeuronMap();
+    void printNeuronMap();
 
     //to set the new sample [added for 50 samples]
     void setConnectivityMatrix(string matrixFilePath);
 
-	// Reads a plain text matrix from a file
-	vector<vector<int>> loadConnectivityMatrix(const string& filePath);
+    // Reads a plain text matrix from a file
+    vector<vector<int>> loadConnectivityMatrix(const string& filePath);
 
-	// Initializes a zero matrix of given dimensions
-	static vector<vector<int>> initializeZeroMatrix(int rows, int cols);
+    // Initializes a zero matrix of given dimensions
+    static vector<vector<int>> initializeZeroMatrix(int rows, int cols);
 
-	// Logs message with timestamp
-	void logToFile(const string& message);
+    // Logs message with timestamp
+    void logToFile(const string& message);
 
-	// Creates a log file name based on current date and time
-	static string createLogFileName();
+    // Creates a log file name based on current date and time
+    static string createLogFileName();
 
     // Gets the log file name
     string getLogFileName() {
@@ -73,8 +73,8 @@ public:
         neuronCoreMap = map;
     }
 
-    ~Utils(){}
-
+    ~Utils() {
+    }
 };
 
-#endif // UTILS_H
+#endif  // UTILS_H

--- a/RoutingEval/common/main.cpp
+++ b/RoutingEval/common/main.cpp
@@ -11,12 +11,13 @@
 #
 ####################################################################################*/
 
-#include "RoutingSimulator.h"
-#include "NeuronMapper.h"
+#include <iostream>
+
 #include "HBSNeuronMapper.h"
 #include "HBSRoutingSimulator.h"
+#include "NeuronMapper.h"
+#include "RoutingSimulator.h"
 #include "Utils.h"
-#include <iostream>
 
 using namespace std;
 
@@ -34,13 +35,11 @@ int main() {
     Utils routingUtils;
     vector<int> neuronsPerCore = {16, 32, 64};
 
-    for(int mapping = 1; mapping <=NUM_MAPPINGS; mapping++){
-
-        for(int neurons_per_core : neuronsPerCore){
-
-            for(int i = 1; i<=NUM_SAMPLES; i++){
-
-                string matrixFilePath = "../data/connectivity_matrix/dynamic_connectivity_matrix_"+to_string(i)+".json";
+    for (int mapping = 1; mapping <= NUM_MAPPINGS; mapping++) {
+        for (int neurons_per_core : neuronsPerCore) {
+            for (int i = 1; i <= NUM_SAMPLES; i++) {
+                string matrixFilePath =
+                    "../data/connectivity_matrix/dynamic_connectivity_matrix_" + to_string(i) + ".json";
                 routingUtils.setConnectivityMatrix(matrixFilePath);
                 vector<vector<int>> connectivityMatrix = routingUtils.getConnectivityMatrix();
                 if (connectivityMatrix.empty()) {
@@ -48,38 +47,52 @@ int main() {
                     return 1;
                 }
 
-                string reportDirectoryNeurogrid = "../data/reports/mapping"+to_string(mapping)+"/reports_"+to_string(NUM_NEURONS)+"_"+to_string(neurons_per_core)+"/neurogrid/waste_metrics_sample"+to_string(i)+".json";
-                string reportDirectoryHBS = "../data/reports/mapping"+to_string(mapping)+"/reports_"+to_string(NUM_NEURONS)+"_"+to_string(neurons_per_core)+"/hbs/waste_metrics_sample"+to_string(i)+".json";
+                string reportDirectoryNeurogrid = "../data/reports/mapping" + to_string(mapping) + "/reports_" +
+                                                  to_string(NUM_NEURONS) + "_" + to_string(neurons_per_core) +
+                                                  "/neurogrid/waste_metrics_sample" + to_string(i) + ".json";
+                string reportDirectoryHBS = "../data/reports/mapping" + to_string(mapping) + "/reports_" +
+                                            to_string(NUM_NEURONS) + "_" + to_string(neurons_per_core) +
+                                            "/hbs/waste_metrics_sample" + to_string(i) + ".json";
                 NeuronMapper neuronMapper(NUM_NEURONS, neurons_per_core, connectivityMatrix);
                 HBSNeuronMapper hbsNeuronMapper(NUM_NEURONS, neurons_per_core, connectivityMatrix);
-                routingUtils.logToFile("NeuronMapper initialized for Neurogrid and HBS routing approaches. Check \"RoutingEval/data/hbs_core_tree.txt\" and \"RoutingEval/data/core_tree.txt\"...");
+                routingUtils.logToFile(
+                    "NeuronMapper initialized for Neurogrid and HBS routing approaches. Check "
+                    "\"RoutingEval/data/hbs_core_tree.txt\" and \"RoutingEval/data/core_tree.txt\"...");
 
                 routingUtils.setNeuronCoreMap(neuronMapper.getNeuronToCoreMap());
                 //routingUtils.printNeuronMap();
 
-                routingUtils.logToFile("\n\n\n========================STARTING NEUROGRID SIMULATION "+to_string(i)+" FOR "+to_string(neurons_per_core)+" NEURONS PER CORE "+"===========================================================\n\n\n");
+                routingUtils.logToFile("\n\n\n========================STARTING NEUROGRID SIMULATION " + to_string(i) +
+                                       " FOR " + to_string(neurons_per_core) + " NEURONS PER CORE " +
+                                       "===========================================================\n\n\n");
                 // Initialize RoutingSimulator and run simulation
-                RoutingSimulator simulator(connectivityMatrix,
-                                        neuronMapper.getNeuronToCoreMap(),
-                                        neuronMapper.getCoreTree(), neuronMapper.getCoreParent(), routingUtils, reportDirectoryNeurogrid);
+                RoutingSimulator simulator(connectivityMatrix, neuronMapper.getNeuronToCoreMap(),
+                                           neuronMapper.getCoreTree(), neuronMapper.getCoreParent(), routingUtils,
+                                           reportDirectoryNeurogrid);
                 simulator.simulate();
 
-                routingUtils.logToFile("\n\n\n========================ENDING NEUROGRID SIMULATION "+to_string(i)+" FOR "+to_string(neurons_per_core)+" NEURONS PER CORE "+"===========================================================\n\n\n");
+                routingUtils.logToFile("\n\n\n========================ENDING NEUROGRID SIMULATION " + to_string(i) +
+                                       " FOR " + to_string(neurons_per_core) + " NEURONS PER CORE " +
+                                       "===========================================================\n\n\n");
 
-                routingUtils.logToFile("\n\n\n========================STARTING HBS SIMULATION "+to_string(i)+" FOR "+to_string(neurons_per_core)+" NEURONS PER CORE "+"===========================================================\n\n\n");
+                routingUtils.logToFile("\n\n\n========================STARTING HBS SIMULATION " + to_string(i) +
+                                       " FOR " + to_string(neurons_per_core) + " NEURONS PER CORE " +
+                                       "===========================================================\n\n\n");
                 HBSRoutingSimulator sim(connectivityMatrix, hbsNeuronMapper.getNeuronToCoreMap(),
-                                        hbsNeuronMapper.getCoreTree(), hbsNeuronMapper.getCoreParent(), routingUtils, reportDirectoryHBS);
+                                        hbsNeuronMapper.getCoreTree(), hbsNeuronMapper.getCoreParent(), routingUtils,
+                                        reportDirectoryHBS);
                 sim.simulate();
                 sim.reportWasteStatistics();
 
-                routingUtils.logToFile("\n\n\n========================ENDING HBS SIMULATION "+to_string(i)+" FOR "+to_string(neurons_per_core)+" NEURONS PER CORE "+"===========================================================\n\n\n");
+                routingUtils.logToFile("\n\n\n========================ENDING HBS SIMULATION " + to_string(i) + " FOR " +
+                                       to_string(neurons_per_core) + " NEURONS PER CORE " +
+                                       "===========================================================\n\n\n");
 
                 // Side-by-side comparison
                 long long neurGridWaste = simulator.getTotalWaste();
-                long long hbsWaste      = sim.getTotalWaste();
+                long long hbsWaste = sim.getTotalWaste();
                 routingUtils.logToFile("\n------------------------------------------------------------");
-                routingUtils.logToFile("COMPARISON  |  mapping=" + to_string(mapping) +
-                                       "  sample=" + to_string(i) +
+                routingUtils.logToFile("COMPARISON  |  mapping=" + to_string(mapping) + "  sample=" + to_string(i) +
                                        "  neurons_per_core=" + to_string(neurons_per_core));
                 routingUtils.logToFile("  Neurogrid total waste : " + to_string(neurGridWaste));
                 routingUtils.logToFile("  HBS       total waste : " + to_string(hbsWaste));
@@ -91,10 +104,9 @@ int main() {
                 else
                     routingUtils.logToFile("  Both techniques produce equal waste");
                 routingUtils.logToFile("------------------------------------------------------------\n");
-            
             }
         }
     }
-        
+
     return 0;
 }


### PR DESCRIPTION
## Summary

- **Correctness fixes**: removed global `nlohmann::json` accumulation across `simulate()` calls and hardcoded `rootCore = 30` in `RoutingSimulator` (now derived dynamically from `coreParent`)
- **Function decomposition**: broke down monolithic methods (`simulate()`, `simulateNeuronToNeuron()`, `assignNeuronsToCores()`, `mapNeurons()`) into focused private helpers to improve readability and structure
- **Header hygiene**: synced `SpikeGenerator.h` to its implementation; moved internal helpers (`logCoreTreeRecursive`, `serializeCoreTree`) to private; removed unimplemented `getParentCore` declaration; corrected HBS description to "Hierarchical Bit String"
- **Dead code removal**: removed commented-out connectivity matrix loading block from `Utils` constructor
- **Formatting**: added `.clang-format` (Google-based, 4-space indent, 120-char limit) and CI step to enforce it on every push

## Test plan

- [x] CI passes (clang-format check + build)
- [x] `make build-cpp` produces a clean binary with no warnings
- [x] `make simulate` runs end-to-end and produces the same JSON reports as before